### PR TITLE
Externalize configuration and clean up profiles

### DIFF
--- a/Behaviors/Actions/ClickBehavior.cs
+++ b/Behaviors/Actions/ClickBehavior.cs
@@ -13,7 +13,7 @@ namespace GPM_driver.Behaviors.Actions
         public ClickBehavior(MouseHelper mouseHelper)
         {
             _mouseHelper = mouseHelper ?? throw new ArgumentNullException(nameof(mouseHelper));
-            _random = new Random(Guid.NewGuid().GetHashCode());
+            _random = RandomProvider.Shared;
         }
 
         public async Task SafeRandomLinkClickAsync(IPage page)

--- a/Behaviors/Actions/IdleBehavior.cs
+++ b/Behaviors/Actions/IdleBehavior.cs
@@ -12,7 +12,7 @@ namespace GPM_driver.Behaviors.Actions
         public IdleBehavior(MouseHelper mouseHelper)
         {
             _mouseHelper = mouseHelper ?? throw new ArgumentNullException(nameof(mouseHelper));
-            _random = new Random(Guid.NewGuid().GetHashCode());
+            _random = RandomProvider.Shared;
         }
 
         public async Task RandomPauseAsync(int minMs = 500, int maxMs = 3000)

--- a/Behaviors/BehaviorBase.cs
+++ b/Behaviors/BehaviorBase.cs
@@ -11,7 +11,7 @@ namespace GPM_driver.Behaviors
     /// </summary>
     internal static class BehaviorBase
     {
-        private static readonly Random _random = new Random(Guid.NewGuid().GetHashCode());
+        private static readonly Random _random = RandomProvider.Shared;
 
         /// <summary>
         /// Performs a random content inspection behavior (text selection, hover over elements, etc.)

--- a/Behaviors/Personas/ClickExplorer.cs
+++ b/Behaviors/Personas/ClickExplorer.cs
@@ -8,7 +8,7 @@ namespace GPM_driver.Behaviors.Personas
 {
     internal class ClickExplorer : IPersona
     {
-        private readonly Random _rng = new Random(Guid.NewGuid().GetHashCode());
+        private readonly Random _rng = RandomProvider.Shared;
 
         public async Task PerformAsync(
             IPage page,

--- a/Behaviors/Personas/DeepReader.cs
+++ b/Behaviors/Personas/DeepReader.cs
@@ -8,7 +8,7 @@ namespace GPM_driver.Behaviors.Personas
 {
     internal class DeepReader : IPersona
     {
-        private readonly Random _rng = new Random(Guid.NewGuid().GetHashCode());
+        private readonly Random _rng = RandomProvider.Shared;
 
         public async Task PerformAsync(
             IPage page,

--- a/Behaviors/Personas/FastScanner.cs
+++ b/Behaviors/Personas/FastScanner.cs
@@ -8,7 +8,7 @@ namespace GPM_driver.Behaviors.Personas
 {
     internal class FastScanner : IPersona
     {
-        private readonly Random _rng = new Random(Guid.NewGuid().GetHashCode());
+        private readonly Random _rng = RandomProvider.Shared;
 
         public async Task PerformAsync(IPage page, MouseHelper mouse, KeyboardHelper keyboard, RetentionBucket bucket, int durationSeconds)
         {

--- a/Behaviors/Personas/IdleLurker.cs
+++ b/Behaviors/Personas/IdleLurker.cs
@@ -8,7 +8,7 @@ namespace GPM_driver.Behaviors.Personas
 {
     internal class IdleLurker : IPersona
     {
-        private readonly Random _rng = new Random(Guid.NewGuid().GetHashCode());
+        private readonly Random _rng = RandomProvider.Shared;
 
         public async Task PerformAsync(
             IPage page,

--- a/Behaviors/UserBehavior.cs
+++ b/Behaviors/UserBehavior.cs
@@ -18,7 +18,7 @@ namespace GPM_driver.Behaviors
         public UserBehavior(IPage page)
         {
             _page = page;
-            _rng = new Random(Guid.NewGuid().GetHashCode());
+            _rng = RandomProvider.Shared;
         }
 
         /// <summary>

--- a/GPM_driver.csproj
+++ b/GPM_driver.csproj
@@ -9,6 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright" Version="1.55.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/GPM_driver.csproj
+++ b/GPM_driver.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GPM_driver.csproj
+++ b/GPM_driver.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Helpers/Helpers.cs
+++ b/Helpers/Helpers.cs
@@ -11,7 +11,6 @@ namespace GPM_driver.Helpers
     {
         public static async Task<IBrowser> ConnectWithRetryAsync(IPlaywright playwright, string remoteAddress, int maxRetries = 5)
         {
-            var random = new Random();
             for (int attempt = 1; attempt <= maxRetries; attempt++)
             {
                 try
@@ -26,7 +25,7 @@ namespace GPM_driver.Helpers
                     Console.WriteLine($"[Playwright] Failed: {ex.Message}");
                     if (attempt == maxRetries) throw;
 
-                    int wait = random.Next(1500, 4000); // jitter wait
+                    int wait = RandomProvider.Next(1500, 4000); // jitter wait
                     Console.WriteLine($"Retrying in {wait} ms...");
                     await Task.Delay(wait);
                 }

--- a/Helpers/Helpers.cs
+++ b/Helpers/Helpers.cs
@@ -1,35 +1,41 @@
-﻿using Microsoft.Playwright;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace GPM_driver.Helpers
 {
     public static class PlaywrightHelper
     {
-        public static async Task<IBrowser> ConnectWithRetryAsync(IPlaywright playwright, string remoteAddress, int maxRetries = 5)
+        public static async Task<IBrowser> ConnectWithRetryAsync(
+            IPlaywright playwright,
+            string remoteAddress,
+            int maxRetries = 5,
+            ILogger? logger = null)
         {
             for (int attempt = 1; attempt <= maxRetries; attempt++)
             {
                 try
                 {
-                    Console.WriteLine($"[Playwright] Attempt {attempt} to connect over CDP...");
+                    logger?.LogInformation("Attempt {Attempt} to connect to Playwright CDP at {RemoteAddress}.", attempt, remoteAddress);
                     var browser = await playwright.Chromium.ConnectOverCDPAsync($"http://{remoteAddress}");
-                    Console.WriteLine("[Playwright] Connected successfully!");
+                    logger?.LogInformation("Playwright connected successfully to {RemoteAddress}.", remoteAddress);
                     return browser;
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[Playwright] Failed: {ex.Message}");
-                    if (attempt == maxRetries) throw;
+                    logger?.LogWarning(ex, "Playwright connection attempt {Attempt} failed.", attempt);
+                    if (attempt == maxRetries)
+                    {
+                        throw;
+                    }
 
-                    int wait = RandomProvider.Next(1500, 4000); // jitter wait
-                    Console.WriteLine($"Retrying in {wait} ms...");
+                    int wait = RandomProvider.Next(1500, 4000);
+                    logger?.LogInformation("Retrying Playwright connection in {Delay} ms.", wait);
                     await Task.Delay(wait);
                 }
             }
+
             throw new Exception("Unable to connect after retries.");
         }
     }

--- a/Helpers/KeyboardHelper.cs
+++ b/Helpers/KeyboardHelper.cs
@@ -12,8 +12,8 @@ namespace GPM_driver.Helpers
         public KeyboardHelper(IPage page)
         {
             _page = page;
-            // Use stronger entropy for more realistic behavior
-            _random = new Random(Guid.NewGuid().GetHashCode());
+            // Use shared RNG to prevent duplicate seeds and allow future overrides
+            _random = RandomProvider.Shared;
         }
 
         /// <summary>

--- a/Helpers/LinkHelper.cs
+++ b/Helpers/LinkHelper.cs
@@ -8,7 +8,7 @@ namespace GPM_driver.Helpers
 {
     internal static class LinkHelper
     {
-        private static readonly Random _random = new Random(Guid.NewGuid().GetHashCode());
+        private static readonly Random _random = RandomProvider.Shared;
 
         /// <summary>
         /// Safely picks a random visible internal link and clicks it.

--- a/Helpers/MouseHelper.cs
+++ b/Helpers/MouseHelper.cs
@@ -20,8 +20,8 @@ namespace GPM_driver.Helpers
         public MouseHelper(IPage page)
         {
             _page = page;
-            // Stronger entropy than default Random()
-            _random = new Random(Guid.NewGuid().GetHashCode());
+            // Use shared RNG to avoid identical seeds across helpers
+            _random = RandomProvider.Shared;
         }
 
         /// <summary>

--- a/Helpers/MouseHelper.cs
+++ b/Helpers/MouseHelper.cs
@@ -160,5 +160,18 @@ namespace GPM_driver.Helpers
 
             await Task.Delay(_random.Next(200, 1000));
         }
+
+        /// <summary>
+        /// Moves the mouse towards an absolute coordinate in the viewport using the same easing logic
+        /// as element-based moves. Useful for lightweight jitter or targeting screen regions.
+        /// </summary>
+        public Task MoveAsync(double x, double y, int steps = 15, bool addJitter = true)
+            => MoveToCoordinatesAsync(x, y, steps, addJitter);
+
+        /// <summary>
+        /// Convenience overload for integer coordinates.
+        /// </summary>
+        public Task MoveAsync(int x, int y, int steps = 15, bool addJitter = true)
+            => MoveAsync((double)x, (double)y, steps, addJitter);
     }
 }

--- a/Helpers/RandomProvider.cs
+++ b/Helpers/RandomProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Security.Cryptography;
+
+namespace GPM_driver.Helpers;
+
+public static class RandomProvider
+{
+    private static int NextSeed() => RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+
+    public static Random Shared => Random.Shared;
+
+    public static Random CreateThreadSafeRandom() => new Random(NextSeed());
+
+    public static int Next(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
+
+    public static double NextDouble() => Random.Shared.NextDouble();
+
+    public static TimeSpan NextDelay(TimeSpan min, TimeSpan max)
+    {
+        if (min > max) throw new ArgumentException("min cannot be greater than max.");
+        var range = max - min;
+        if (range <= TimeSpan.Zero) return min;
+        var fraction = Random.Shared.NextDouble();
+        return min + TimeSpan.FromMilliseconds(range.TotalMilliseconds * fraction);
+    }
+}

--- a/Helpers/RetryHelper.cs
+++ b/Helpers/RetryHelper.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GPM_driver.Helpers;
+
+public static class RetryHelper
+{
+    public static Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> operation, int maxAttempts = 3, TimeSpan? initialDelay = null, double backoffFactor = 2.0, TimeSpan? maxDelay = null, string? operationName = null, CancellationToken cancellationToken = default)
+        => ExecuteWithRetryInternalAsync(operation, maxAttempts, initialDelay, backoffFactor, maxDelay, operationName, cancellationToken);
+
+    public static Task ExecuteWithRetryAsync(Func<Task> operation, int maxAttempts = 3, TimeSpan? initialDelay = null, double backoffFactor = 2.0, TimeSpan? maxDelay = null, string? operationName = null, CancellationToken cancellationToken = default)
+        => ExecuteWithRetryInternalAsync<object?>(async () =>
+        {
+            await operation().ConfigureAwait(false);
+            return null;
+        }, maxAttempts, initialDelay, backoffFactor, maxDelay, operationName, cancellationToken);
+
+    private static async Task<T> ExecuteWithRetryInternalAsync<T>(Func<Task<T>> operation, int maxAttempts, TimeSpan? initialDelay, double backoffFactor, TimeSpan? maxDelay, string? operationName, CancellationToken cancellationToken)
+    {
+        if (operation == null) throw new ArgumentNullException(nameof(operation));
+        if (maxAttempts <= 0) throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+        if (backoffFactor < 1.0) throw new ArgumentOutOfRangeException(nameof(backoffFactor));
+
+        TimeSpan delay = initialDelay ?? TimeSpan.FromMilliseconds(500);
+        TimeSpan maximumDelay = maxDelay ?? TimeSpan.FromSeconds(10);
+        string name = string.IsNullOrWhiteSpace(operationName) ? "Operation" : operationName!;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                return await operation().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (attempt < maxAttempts)
+            {
+                var jitter = TimeSpan.FromMilliseconds(RandomProvider.Next(100, 400));
+                var wait = delay + jitter;
+                Console.WriteLine($"[{name}] attempt {attempt} failed: {ex.Message}. Retrying in {wait.TotalSeconds:F1}s...");
+                await Task.Delay(wait, cancellationToken).ConfigureAwait(false);
+
+                double nextDelayMs = Math.Min(maximumDelay.TotalMilliseconds, delay.TotalMilliseconds * backoffFactor);
+                delay = TimeSpan.FromMilliseconds(nextDelayMs);
+            }
+        }
+
+        // Final attempt without catching to allow exception to bubble up
+        return await operation().ConfigureAwait(false);
+    }
+}

--- a/Helpers/ScrollHelper.cs
+++ b/Helpers/ScrollHelper.cs
@@ -6,7 +6,7 @@ namespace GPM_driver.Helpers
 {
     internal static class ScrollHelper
     {
-        private static readonly Random _random = new Random(Guid.NewGuid().GetHashCode());
+        private static readonly Random _random = RandomProvider.Shared;
 
         public static async Task ScrollRandomAsync(IPage page, int scrolls = 5, bool allowUpward = true)
         {

--- a/Helpers/TabHelper.cs
+++ b/Helpers/TabHelper.cs
@@ -11,7 +11,7 @@ namespace GPM_driver.Helpers
     /// </summary>
     internal static class TabHelper
     {
-        private static readonly Random _random = new Random(Guid.NewGuid().GetHashCode());
+        private static readonly Random _random = RandomProvider.Shared;
 
         /// <summary>
         /// ClickExplorer-specific behavior for exploring new tabs

--- a/Helpers/YouTubeUrlHelper.cs
+++ b/Helpers/YouTubeUrlHelper.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace GPM_driver.Helpers;
+
+internal static class YouTubeUrlHelper
+{
+    internal enum YouTubeVideoKind
+    {
+        Unknown,
+        Video,
+        Playlist,
+        Short,
+        Live
+    }
+
+    internal static YouTubeVideoKind GetVideoKind(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return YouTubeVideoKind.Unknown;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return YouTubeVideoKind.Unknown;
+        }
+
+        string path = uri.AbsolutePath ?? string.Empty;
+        path = path.TrimEnd('/');
+
+        if (path.Contains("/shorts", StringComparison.OrdinalIgnoreCase))
+        {
+            return YouTubeVideoKind.Short;
+        }
+
+        if (path.Contains("/live", StringComparison.OrdinalIgnoreCase))
+        {
+            return YouTubeVideoKind.Live;
+        }
+
+        if (path.Contains("/playlist", StringComparison.OrdinalIgnoreCase))
+        {
+            return YouTubeVideoKind.Playlist;
+        }
+
+        if (path.Contains("/watch", StringComparison.OrdinalIgnoreCase))
+        {
+            if (HasQueryParameter(uri, "list"))
+            {
+                return YouTubeVideoKind.Playlist;
+            }
+
+            if (HasQueryParameter(uri, "v"))
+            {
+                return YouTubeVideoKind.Video;
+            }
+        }
+
+        if (path.Contains("/embed", StringComparison.OrdinalIgnoreCase))
+        {
+            return YouTubeVideoKind.Video;
+        }
+
+        return YouTubeVideoKind.Video;
+    }
+
+    internal static bool IsShort(string? url) => GetVideoKind(url) == YouTubeVideoKind.Short;
+
+    private static bool HasQueryParameter(Uri uri, string name)
+    {
+        if (string.IsNullOrEmpty(uri.Query))
+        {
+            return false;
+        }
+
+        var segments = uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var segment in segments)
+        {
+            var parts = segment.Split('=', 2, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+            {
+                continue;
+            }
+
+            if (parts[0].Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return parts.Length == 1 || !string.IsNullOrEmpty(parts[1]);
+            }
+        }
+
+        return false;
+    }
+}

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -1,0 +1,43 @@
+namespace GPM_driver.Models;
+
+public class AppSettings
+{
+    public GpmSettings Gpm { get; set; } = new();
+    public SearchSettings Search { get; set; } = new();
+}
+
+public class GpmSettings
+{
+    public string BaseUrl { get; set; } = string.Empty;
+    public string ProxyApiUrl { get; set; } = string.Empty;
+    public ProfileTemplate Profile { get; set; } = new();
+}
+
+public class ProfileTemplate
+{
+    public string ProfileName { get; set; } = "Test profile";
+    public string BrowserCore { get; set; } = "chromium";
+    public string BrowserName { get; set; } = "Chrome";
+    public bool IsRandomBrowserVersion { get; set; }
+        = false;
+    public string StartupUrls { get; set; } = string.Empty;
+    public bool IsMaskedFont { get; set; } = true;
+    public bool IsNoiseCanvas { get; set; } = true;
+    public bool IsNoiseWebgl { get; set; } = false;
+    public bool IsNoiseClientRect { get; set; } = true;
+    public bool IsNoiseAudioContext { get; set; } = true;
+    public bool IsRandomScreen { get; set; } = true;
+    public bool IsMaskedWebglData { get; set; } = true;
+    public bool IsMaskedMediaDevice { get; set; } = true;
+    public bool IsRandomOs { get; set; }
+        = false;
+    public string Os { get; set; } = "Windows 10";
+    public string[] OperatingSystems { get; set; } = new[] { "Windows 10" };
+    public int WebrtcMode { get; set; } = 2;
+}
+
+public class SearchSettings
+{
+    public string SmartSearchKeywordDirectory { get; set; } = string.Empty;
+    public string GoogleKeywordDirectory { get; set; } = string.Empty;
+}

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -72,4 +72,12 @@ public class YouTubeWarmupSettings
     public int MinDelayBetweenActionsMs { get; set; } = 2000;
     public int MaxDelayBetweenActionsMs { get; set; } = 5000;
     public string[] Domains { get; set; } = new[] { "https://www.youtube.com", "https://www.youtube.com/feed/explore" };
+    public string IdentityCacheDirectory { get; set; } = "youtube-identities";
+    public int IdentityKeywordFileCount { get; set; } = 2;
+    public double RecommendationChainProbability { get; set; } = 0.55;
+    public int MinRecommendationChainLength { get; set; } = 1;
+    public int MaxRecommendationChainLength { get; set; } = 3;
+    public double AutoplayFollowProbability { get; set; } = 0.35;
+    public int MinShortSequenceLength { get; set; } = 2;
+    public int MaxShortSequenceLength { get; set; } = 5;
 }

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -43,4 +43,14 @@ public class SearchSettings
 {
     public string SmartSearchKeywordDirectory { get; set; } = string.Empty;
     public string GoogleKeywordDirectory { get; set; } = string.Empty;
+    public GoogleWarmupSettings GoogleWarmup { get; set; } = new();
+}
+
+public class GoogleWarmupSettings
+{
+    public int MinSearches { get; set; } = 1;
+    public int MaxSearches { get; set; } = 3;
+    public double ContinueProbability { get; set; } = 0.5;
+    public int MaxBacktracks { get; set; } = 2;
+    public string[] Domains { get; set; } = new[] { "https://www.google.com", "https://www.google.com.vn" };
 }

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -10,6 +10,9 @@ public class GpmSettings
 {
     public string BaseUrl { get; set; } = string.Empty;
     public string ProxyApiUrl { get; set; } = string.Empty;
+    public int ApiRetryAttempts { get; set; } = 3;
+    public int ApiRetryInitialDelayMs { get; set; } = 500;
+    public int ApiRetryMaxDelayMs { get; set; } = 8000;
     public ProfileTemplate Profile { get; set; } = new();
 }
 

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -44,6 +44,8 @@ public class SearchSettings
     public string SmartSearchKeywordDirectory { get; set; } = string.Empty;
     public string GoogleKeywordDirectory { get; set; } = string.Empty;
     public GoogleWarmupSettings GoogleWarmup { get; set; } = new();
+    public string YouTubeKeywordDirectory { get; set; } = string.Empty;
+    public YouTubeWarmupSettings YouTubeWarmup { get; set; } = new();
 }
 
 public class GoogleWarmupSettings
@@ -53,4 +55,21 @@ public class GoogleWarmupSettings
     public double ContinueProbability { get; set; } = 0.5;
     public int MaxBacktracks { get; set; } = 2;
     public string[] Domains { get; set; } = new[] { "https://www.google.com", "https://www.google.com.vn" };
+}
+
+public class YouTubeWarmupSettings
+{
+    public bool Enabled { get; set; } = true;
+    public int MinInteractions { get; set; } = 2;
+    public int MaxInteractions { get; set; } = 5;
+    public double ContinueProbability { get; set; } = 0.35;
+    public int MinWatchMilliseconds { get; set; } = 20000;
+    public int MaxWatchMilliseconds { get; set; } = 55000;
+    public int MinShortWatchMilliseconds { get; set; } = 8000;
+    public int MaxShortWatchMilliseconds { get; set; } = 20000;
+    public double SearchWeight { get; set; } = 0.5;
+    public double ShortsWeight { get; set; } = 0.25;
+    public int MinDelayBetweenActionsMs { get; set; } = 2000;
+    public int MaxDelayBetweenActionsMs { get; set; } = 5000;
+    public string[] Domains { get; set; } = new[] { "https://www.youtube.com", "https://www.youtube.com/feed/explore" };
 }

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -80,4 +80,11 @@ public class YouTubeWarmupSettings
     public double AutoplayFollowProbability { get; set; } = 0.35;
     public int MinShortSequenceLength { get; set; } = 2;
     public int MaxShortSequenceLength { get; set; } = 5;
+    public string Persona { get; set; } = "Generalist";
+    public string Region { get; set; } = "Global";
+    public string Language { get; set; } = "en-US";
+    public string? Timezone { get; set; }
+        = null;
+    public string[] Behaviors { get; set; }
+        = new[] { "Search", "Home", "Shorts", "Recommendations" };
 }

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -77,6 +77,7 @@ public class YouTubeWarmupSettings
     public double RecommendationChainProbability { get; set; } = 0.55;
     public int MinRecommendationChainLength { get; set; } = 1;
     public int MaxRecommendationChainLength { get; set; } = 3;
+    public int MaxRecommendationDepth { get; set; } = 3;
     public double AutoplayFollowProbability { get; set; } = 0.35;
     public int MinShortSequenceLength { get; set; } = 2;
     public int MaxShortSequenceLength { get; set; } = 5;

--- a/Models/ProfileModels.cs
+++ b/Models/ProfileModels.cs
@@ -7,6 +7,38 @@ using System.Text.Json.Serialization;
 
 namespace GPM_driver.Models
 {
+    public class CreateProfileRequest
+    {
+        [JsonPropertyName("profile_name")] public string ProfileName { get; set; } = string.Empty;
+        [JsonPropertyName("browser_core")] public string BrowserCore { get; set; } = "chromium";
+        [JsonPropertyName("browser_name")] public string BrowserName { get; set; } = "Chrome";
+        [JsonPropertyName("browser_version")] public string? BrowserVersion { get; set; }
+            = null;
+        [JsonPropertyName("is_random_browser_version")] public bool IsRandomBrowserVersion { get; set; }
+            = false;
+        [JsonPropertyName("raw_proxy")] public string RawProxy { get; set; } = string.Empty;
+        [JsonPropertyName("startup_urls")] public string StartupUrls { get; set; } = string.Empty;
+        [JsonPropertyName("is_masked_font")] public bool IsMaskedFont { get; set; }
+            = true;
+        [JsonPropertyName("is_noise_canvas")] public bool IsNoiseCanvas { get; set; }
+            = true;
+        [JsonPropertyName("is_noise_webgl")] public bool IsNoiseWebgl { get; set; }
+            = false;
+        [JsonPropertyName("is_noise_client_rect")] public bool IsNoiseClientRect { get; set; }
+            = true;
+        [JsonPropertyName("is_noise_audio_context")] public bool IsNoiseAudioContext { get; set; }
+            = true;
+        [JsonPropertyName("is_random_screen")] public bool IsRandomScreen { get; set; }
+            = true;
+        [JsonPropertyName("is_masked_webgl_data")] public bool IsMaskedWebglData { get; set; }
+            = true;
+        [JsonPropertyName("is_masked_media_device")] public bool IsMaskedMediaDevice { get; set; }
+            = true;
+        [JsonPropertyName("is_random_os")] public bool IsRandomOs { get; set; } = false;
+        [JsonPropertyName("os")] public string Os { get; set; } = "Windows 10";
+        [JsonPropertyName("webrtc_mode")] public int WebrtcMode { get; set; } = 2;
+    }
+
     public class CreateProfileData
     {
         [JsonPropertyName("id")] public string id { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -1,117 +1,176 @@
-﻿using GPM_driver.Models;
-using GPM_driver.Services;
-using Microsoft.Playwright;
-using System;
-using System.Threading.Tasks;
-using GPM_driver.Helpers;
 using GPM_driver.Behaviors;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using GPM_driver.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Playwright;
 
 class Program
 {
-
     static async Task Main()
     {
-        string gpmBase = "http://127.0.0.1:19995";
-        string proxyUrl = "https://proxyxoay.shop/api/get.php?key=BnQqcrAVCtRAauUjUUXyXe&&nhamang=random&&tinhthanh=0";
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .Build();
 
-        using var gpm = new GPM_API(gpmBase);
+        var settings = configuration.Get<AppSettings>() ?? throw new InvalidOperationException("Configuration could not be loaded.");
 
-
-        // 1) Fetch rotating proxy
-        ProxyXoayResponse proxy = await gpm.FetchRotatingProxyAsync(proxyUrl);
-        Console.WriteLine($"HTTP: {proxy.proxyhttp}\nSOCKS5: {proxy.proxysocks5}\nMessage: {proxy.message}");
-
-        // 2) Create profile with fetched proxy
-        var random1 = new Random();
-        var osVersions = new[] { "Windows 10", "Windows 11" };
-        var selectedOs = osVersions[random1.Next(osVersions.Length)];
-        var profilePayload = new
+        if (string.IsNullOrWhiteSpace(settings.Gpm.BaseUrl))
         {
-            profile_name = "Test profile",
-            browser_core = "chromium",
-            browser_name = "Chrome",
-            //browser_version = "139.0.7258.139",
-            is_random_browser_version = false,
-            raw_proxy = proxy.proxyhttp,   // inject fetched proxy
-            startup_urls = "",
-            is_masked_font = true,
-            is_noise_canvas = true,
-            is_noise_webgl = false,
-            is_noise_client_rect = true,
-            is_noise_audio_context = true,
-            is_random_screen = true,
-            is_masked_webgl_data = true,
-            is_masked_media_device = true,
-            is_random_os = false,
-            os = "Windows 10",
-            webrtc_mode = 2
-        };
-
-        CreateProfileResponse createResp = await gpm.CreateProfileAsync(profilePayload);
-        string profileId = createResp?.data?.id;
-        string browser_version = createResp?.data?.browser_version;
-        Console.WriteLine($"Created profile id: {profileId}");
-        Console.WriteLine($"Browser version: {browser_version}");
-
-        if (string.IsNullOrEmpty(profileId))
-        {
-            Console.WriteLine("Failed to create profile or id missing.");
-            return;
+            throw new InvalidOperationException("GPM base URL is not configured.");
         }
 
-        // 3) Start profile
-        StartProfileResponse startResp = await gpm.StartProfileAsync(profileId);
-        Console.WriteLine($"Driver path: {startResp.data.driver_path}");
-        Console.WriteLine($"Remote debug address: {startResp.data.remote_debugging_address}");
+        if (string.IsNullOrWhiteSpace(settings.Gpm.ProxyApiUrl))
+        {
+            throw new InvalidOperationException("Proxy API URL is not configured.");
+        }
 
-        // 4) Connect Playwright to remote debugging
-        using var playwright = await Playwright.CreateAsync();
-        var random = new Random();
-        var delayMilliseconds = random.Next(1500, 3001); // 5000ms to 10000ms (5-10 seconds)
-        //var browser = await playwright.Chromium.ConnectOverCDPAsync($"http://{startResp.data.remote_debugging_address}");
-        var browser = await PlaywrightHelper.ConnectWithRetryAsync(playwright, startResp.data.remote_debugging_address);
-        var context = browser.Contexts[0];
-        // Get the first available page instead of creating a new one
-        var pages = context.Pages;
-        var page = pages.Count > 0 ? pages[0] : await context.NewPageAsync();
-        //5) Use IpHeyService
-        var ipHeyService = new IpHeyService(page);
-        IpHeyResult ipHeyResult = await ipHeyService.CheckAsync();
-        Console.WriteLine($"Status: {ipHeyResult.Status}");
-        Console.WriteLine($"Browser: {ipHeyResult.Browser}");
-        Console.WriteLine($"Location: {ipHeyResult.Location}");
-        Console.WriteLine($"IP: {ipHeyResult.Ip}");
-        Console.WriteLine($"Hardware: {ipHeyResult.Hardware}");
-        Console.WriteLine($"Software: {ipHeyResult.Software}");
+        using var gpm = new GPM_API(settings.Gpm.BaseUrl);
 
-        //6) Use IpFighterService
-        var ipFighter = new IpFighterService(page);
-        IpFighterResult result = await ipFighter.CheckIpAsync();
-        Console.WriteLine($"ISP: {result.Isp}");
-        Console.WriteLine($"Blacklist: {result.Blacklist}");
-        Console.WriteLine($"Proxy: {result.Proxy}");
-        Console.WriteLine($"WebRTC: {result.WebRTC}");
-        Console.WriteLine($"Score: {result.Score}");
-        Console.WriteLine($"City: {result.City}");
-        Console.WriteLine($"Country: {result.Country}");
-        Console.WriteLine($"Hostname: {result.Hostname}");
-        Console.WriteLine($"DNS: {result.DNS}");
-        Console.WriteLine($"Blacklist Details: {result.BlacklistDetails}");
-        Console.WriteLine($"Blacklist Servers: {result.BlacklistServers}");
-        // --- 7) Use SmartSearch ---
-        var keywordFolder1 = @"E:\Google_Farm\google"; // path to your keyword text files
-        var smartSearch = new SmartSearchService(page, browser, keywordFolder1);
+        string? profileId = null;
+        StartProfileResponse? startResponse = null;
 
-        // Start searching all keywords
-        await smartSearch.SearchOneRandomKeywordAsync();
-        // --- 7) Use GoogleSearchService ---
-        var googleSearch = new GoogleSearchService(context);
-        //var keywordFolder = @"E:\Google_Farm\google"; // path to your keyword text files
-        var currentPage = await googleSearch.SearchOneRandomKeywordAsync(@"E:\Google_Farm\Keyword_Search\");
-        // 8) Choice of result on result page google - use the page after navigation
-        var userBehavior = new GPM_driver.Behaviors.UserBehavior(currentPage);
-        await userBehavior.RunAsync();
+        try
+        {
+            // 1) Fetch rotating proxy
+            ProxyXoayResponse proxy = await gpm.FetchRotatingProxyAsync(settings.Gpm.ProxyApiUrl);
+            Console.WriteLine($"HTTP: {proxy.proxyhttp}\nSOCKS5: {proxy.proxysocks5}\nMessage: {proxy.message}");
 
+            // 2) Create profile with fetched proxy
+            var profileTemplate = settings.Gpm.Profile;
+            var osOptions = profileTemplate.OperatingSystems?.Length > 0
+                ? profileTemplate.OperatingSystems
+                : new[] { profileTemplate.Os };
+            var selectedOs = osOptions[Random.Shared.Next(osOptions.Length)];
+
+            var profileRequest = new CreateProfileRequest
+            {
+                ProfileName = profileTemplate.ProfileName,
+                BrowserCore = profileTemplate.BrowserCore,
+                BrowserName = profileTemplate.BrowserName,
+                IsRandomBrowserVersion = profileTemplate.IsRandomBrowserVersion,
+                RawProxy = proxy.proxyhttp,
+                StartupUrls = profileTemplate.StartupUrls,
+                IsMaskedFont = profileTemplate.IsMaskedFont,
+                IsNoiseCanvas = profileTemplate.IsNoiseCanvas,
+                IsNoiseWebgl = profileTemplate.IsNoiseWebgl,
+                IsNoiseClientRect = profileTemplate.IsNoiseClientRect,
+                IsNoiseAudioContext = profileTemplate.IsNoiseAudioContext,
+                IsRandomScreen = profileTemplate.IsRandomScreen,
+                IsMaskedWebglData = profileTemplate.IsMaskedWebglData,
+                IsMaskedMediaDevice = profileTemplate.IsMaskedMediaDevice,
+                IsRandomOs = profileTemplate.IsRandomOs,
+                Os = selectedOs,
+                WebrtcMode = profileTemplate.WebrtcMode
+            };
+
+            CreateProfileResponse createResp = await gpm.CreateProfileAsync(profileRequest);
+            profileId = createResp?.data?.id;
+            string? browserVersion = createResp?.data?.browser_version;
+            Console.WriteLine($"Created profile id: {profileId}");
+            Console.WriteLine($"Browser version: {browserVersion}");
+
+            if (string.IsNullOrEmpty(profileId))
+            {
+                Console.WriteLine("Failed to create profile or id missing.");
+                return;
+            }
+
+            // 3) Start profile
+            startResponse = await gpm.StartProfileAsync(profileId);
+            Console.WriteLine($"Driver path: {startResponse.data.driver_path}");
+            Console.WriteLine($"Remote debug address: {startResponse.data.remote_debugging_address}");
+
+            // 4) Connect Playwright to remote debugging
+            using var playwright = await Playwright.CreateAsync();
+            var browser = await PlaywrightHelper.ConnectWithRetryAsync(playwright, startResponse.data.remote_debugging_address);
+            var context = browser.Contexts[0];
+            var pages = context.Pages;
+            var page = pages.Count > 0 ? pages[0] : await context.NewPageAsync();
+
+            //5) Use IpHeyService
+            var ipHeyService = new IpHeyService(page);
+            IpHeyResult ipHeyResult = await ipHeyService.CheckAsync();
+            Console.WriteLine($"Status: {ipHeyResult.Status}");
+            Console.WriteLine($"Browser: {ipHeyResult.Browser}");
+            Console.WriteLine($"Location: {ipHeyResult.Location}");
+            Console.WriteLine($"IP: {ipHeyResult.Ip}");
+            Console.WriteLine($"Hardware: {ipHeyResult.Hardware}");
+            Console.WriteLine($"Software: {ipHeyResult.Software}");
+
+            //6) Use IpFighterService
+            var ipFighter = new IpFighterService(page);
+            IpFighterResult result = await ipFighter.CheckIpAsync();
+            Console.WriteLine($"ISP: {result.Isp}");
+            Console.WriteLine($"Blacklist: {result.Blacklist}");
+            Console.WriteLine($"Proxy: {result.Proxy}");
+            Console.WriteLine($"WebRTC: {result.WebRTC}");
+            Console.WriteLine($"Score: {result.Score}");
+            Console.WriteLine($"City: {result.City}");
+            Console.WriteLine($"Country: {result.Country}");
+            Console.WriteLine($"Hostname: {result.Hostname}");
+            Console.WriteLine($"DNS: {result.DNS}");
+            Console.WriteLine($"Blacklist Details: {result.BlacklistDetails}");
+            Console.WriteLine($"Blacklist Servers: {result.BlacklistServers}");
+
+            // --- 7) Use SmartSearch ---
+            if (!string.IsNullOrWhiteSpace(settings.Search.SmartSearchKeywordDirectory))
+            {
+                var smartSearch = new SmartSearchService(page, browser, settings.Search.SmartSearchKeywordDirectory);
+                await smartSearch.SearchOneRandomKeywordAsync();
+            }
+            else
+            {
+                Console.WriteLine("SmartSearch keyword directory not configured. Skipping SmartSearchService.");
+            }
+
+            // --- 8) Use GoogleSearchService ---
+            if (!string.IsNullOrWhiteSpace(settings.Search.GoogleKeywordDirectory))
+            {
+                var googleSearch = new GoogleSearchService(context);
+                var currentPage = await googleSearch.SearchOneRandomKeywordAsync(settings.Search.GoogleKeywordDirectory);
+                var userBehavior = new UserBehavior(currentPage);
+                await userBehavior.RunAsync();
+            }
+            else
+            {
+                Console.WriteLine("Google keyword directory not configured. Skipping GoogleSearchService.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unhandled error: {ex.Message}\n{ex}");
+            throw;
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(profileId))
+            {
+                if (startResponse?.data?.profile_id != null)
+                {
+                    try
+                    {
+                        await gpm.StopProfileAsync(profileId);
+                        Console.WriteLine($"Stopped profile {profileId}.");
+                    }
+                    catch (Exception stopEx)
+                    {
+                        Console.Error.WriteLine($"Failed to stop profile {profileId}: {stopEx.Message}");
+                    }
+                }
+
+                try
+                {
+                    await gpm.DeleteProfileAsync(profileId);
+                    Console.WriteLine($"Deleted profile {profileId}.");
+                }
+                catch (Exception deleteEx)
+                {
+                    Console.Error.WriteLine($"Failed to delete profile {profileId}: {deleteEx.Message}");
+                }
+            }
+        }
     }
 }
-

--- a/Program.cs
+++ b/Program.cs
@@ -135,7 +135,7 @@ class Program
             logger.LogInformation("Attached to remote browser. Context currently has {PageCount} page(s).", context.Pages?.Count ?? 0);
 
             var warmupLogger = loggerFactory.CreateLogger<WarmupSession>();
-            var warmup = new WarmupSession(settings, browser, context, warmupLogger, loggerFactory);
+            var warmup = new WarmupSession(settings, browser, context, warmupLogger, loggerFactory, profileId);
             await warmup.RunAsync();
         }
         catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,8 @@
-using GPM_driver.Behaviors;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
 using GPM_driver.Services;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 
 class Program
@@ -27,6 +27,20 @@ class Program
             throw new InvalidOperationException("Proxy API URL is not configured.");
         }
 
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder
+                .SetMinimumLevel(LogLevel.Information)
+                .AddSimpleConsole(options =>
+                {
+                    options.TimestampFormat = "HH:mm:ss ";
+                    options.SingleLine = true;
+                });
+        });
+
+        var logger = loggerFactory.CreateLogger<Program>();
+        logger.LogInformation("Starting GPM driver with profile template '{ProfileName}'.", settings.Gpm.Profile.ProfileName);
+
         using var gpm = new GPM_API(settings.Gpm.BaseUrl);
 
         int apiRetries = Math.Max(1, settings.Gpm.ApiRetryAttempts);
@@ -43,16 +57,15 @@ class Program
 
         try
         {
-            // 1) Fetch rotating proxy with retries
+            logger.LogInformation("Fetching rotating proxy from {ProxyEndpoint}.", settings.Gpm.ProxyApiUrl);
             ProxyXoayResponse proxy = await RetryHelper.ExecuteWithRetryAsync(
                 () => gpm.FetchRotatingProxyAsync(settings.Gpm.ProxyApiUrl),
                 maxAttempts: apiRetries,
                 initialDelay: initialDelay,
                 maxDelay: maxDelay,
                 operationName: "ProxyFetch");
-            Console.WriteLine($"HTTP: {proxy.proxyhttp}\nSOCKS5: {proxy.proxysocks5}\nMessage: {proxy.message}");
+            logger.LogInformation("Proxy obtained. HTTP={HttpProxy} SOCKS5={SocksProxy} Message={Message}.", proxy.proxyhttp, proxy.proxysocks5, proxy.message);
 
-            // 2) Create profile with fetched proxy
             var profileTemplate = settings.Gpm.Profile;
             var osOptions = profileTemplate.OperatingSystems?.Length > 0
                 ? profileTemplate.OperatingSystems
@@ -80,6 +93,7 @@ class Program
                 WebrtcMode = profileTemplate.WebrtcMode
             };
 
+            logger.LogInformation("Creating profile '{ProfileName}' using OS '{SelectedOs}'.", profileRequest.ProfileName, selectedOs);
             CreateProfileResponse createResp = await RetryHelper.ExecuteWithRetryAsync(
                 () => gpm.CreateProfileAsync(profileRequest),
                 maxAttempts: apiRetries,
@@ -89,16 +103,14 @@ class Program
 
             profileId = createResp?.data?.id;
             string? browserVersion = createResp?.data?.browser_version;
-            Console.WriteLine($"Created profile id: {profileId}");
-            Console.WriteLine($"Browser version: {browserVersion}");
+            logger.LogInformation("Profile created with id {ProfileId} and browser version {BrowserVersion}.", profileId, browserVersion ?? "unknown");
 
             if (string.IsNullOrEmpty(profileId))
             {
-                Console.WriteLine("Failed to create profile or id missing.");
+                logger.LogError("Failed to create profile or id missing. Aborting execution.");
                 return;
             }
 
-            // 3) Start profile
             startResponse = await RetryHelper.ExecuteWithRetryAsync(
                 () => gpm.StartProfileAsync(profileId),
                 maxAttempts: apiRetries,
@@ -108,100 +120,27 @@ class Program
 
             if (startResponse?.data == null)
             {
-                Console.WriteLine("Failed to start profile; start response data was null.");
+                logger.LogError("Failed to start profile; start response data was null.");
                 return;
             }
 
-            Console.WriteLine($"Driver path: {startResponse.data.driver_path}");
-            Console.WriteLine($"Remote debug address: {startResponse.data.remote_debugging_address}");
+            logger.LogInformation("Profile started. Driver path={DriverPath}, remote debugging={RemoteDebugging}.", startResponse.data.driver_path, startResponse.data.remote_debugging_address);
 
-            // 4) Connect Playwright to remote debugging
             using var playwright = await Playwright.CreateAsync();
-            var browser = await PlaywrightHelper.ConnectWithRetryAsync(playwright, startResponse.data.remote_debugging_address);
+            var browser = await PlaywrightHelper.ConnectWithRetryAsync(
+                playwright,
+                startResponse.data.remote_debugging_address,
+                logger: loggerFactory.CreateLogger("PlaywrightConnection"));
             var context = browser.Contexts.Count > 0 ? browser.Contexts[0] : await browser.NewContextAsync();
-            var pages = context.Pages;
-            var page = pages.Count > 0 ? pages[0] : await context.NewPageAsync();
+            logger.LogInformation("Attached to remote browser. Context currently has {PageCount} page(s).", context.Pages?.Count ?? 0);
 
-            //5) Use IpHeyService
-            try
-            {
-                var ipHeyService = new IpHeyService(page);
-                IpHeyResult ipHeyResult = await ipHeyService.CheckAsync();
-                Console.WriteLine($"Status: {ipHeyResult.Status}");
-                Console.WriteLine($"Browser: {ipHeyResult.Browser}");
-                Console.WriteLine($"Location: {ipHeyResult.Location}");
-                Console.WriteLine($"IP: {ipHeyResult.Ip}");
-                Console.WriteLine($"Hardware: {ipHeyResult.Hardware}");
-                Console.WriteLine($"Software: {ipHeyResult.Software}");
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"[IpHey] Failed to complete check: {ex.Message}");
-            }
-
-            //6) Use IpFighterService
-            try
-            {
-                var ipFighter = new IpFighterService(page);
-                IpFighterResult result = await ipFighter.CheckIpAsync();
-                Console.WriteLine($"ISP: {result.Isp}");
-                Console.WriteLine($"Blacklist: {result.Blacklist}");
-                Console.WriteLine($"Proxy: {result.Proxy}");
-                Console.WriteLine($"WebRTC: {result.WebRTC}");
-                Console.WriteLine($"Score: {result.Score}");
-                Console.WriteLine($"City: {result.City}");
-                Console.WriteLine($"Country: {result.Country}");
-                Console.WriteLine($"Hostname: {result.Hostname}");
-                Console.WriteLine($"DNS: {result.DNS}");
-                Console.WriteLine($"Blacklist Details: {result.BlacklistDetails}");
-                Console.WriteLine($"Blacklist Servers: {result.BlacklistServers}");
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"[IpFighter] Failed to complete check: {ex.Message}");
-            }
-
-            // --- 7) Use SmartSearch ---
-            if (!string.IsNullOrWhiteSpace(settings.Search.SmartSearchKeywordDirectory))
-            {
-                try
-                {
-                    var smartSearch = new SmartSearchService(page, browser, settings.Search.SmartSearchKeywordDirectory);
-                    await smartSearch.SearchOneRandomKeywordAsync();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"[SmartSearch] Failed: {ex.Message}");
-                }
-            }
-            else
-            {
-                Console.WriteLine("SmartSearch keyword directory not configured. Skipping SmartSearchService.");
-            }
-
-            // --- 8) Use GoogleSearchService ---
-            if (!string.IsNullOrWhiteSpace(settings.Search.GoogleKeywordDirectory))
-            {
-                try
-                {
-                    var googleSearch = new GoogleSearchService(context);
-                    var currentPage = await googleSearch.SearchOneRandomKeywordAsync(settings.Search.GoogleKeywordDirectory);
-                    var userBehavior = new UserBehavior(currentPage);
-                    await userBehavior.RunAsync();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"[GoogleSearch] Failed: {ex.Message}");
-                }
-            }
-            else
-            {
-                Console.WriteLine("Google keyword directory not configured. Skipping GoogleSearchService.");
-            }
+            var warmupLogger = loggerFactory.CreateLogger<WarmupSession>();
+            var warmup = new WarmupSession(settings, browser, context, warmupLogger, loggerFactory);
+            await warmup.RunAsync();
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Unhandled error: {ex.Message}\n{ex}");
+            logger.LogError(ex, "Unhandled error during orchestrator run.");
             Environment.ExitCode = -1;
         }
         finally
@@ -213,22 +152,22 @@ class Program
                     try
                     {
                         await gpm.StopProfileAsync(profileId);
-                        Console.WriteLine($"Stopped profile {profileId}.");
+                        logger.LogInformation("Stopped profile {ProfileId}.", profileId);
                     }
                     catch (Exception stopEx)
                     {
-                        Console.Error.WriteLine($"Failed to stop profile {profileId}: {stopEx.Message}");
+                        logger.LogWarning(stopEx, "Failed to stop profile {ProfileId}.", profileId);
                     }
                 }
 
                 try
                 {
                     await gpm.DeleteProfileAsync(profileId);
-                    Console.WriteLine($"Deleted profile {profileId}.");
+                    logger.LogInformation("Deleted profile {ProfileId}.", profileId);
                 }
                 catch (Exception deleteEx)
                 {
-                    Console.Error.WriteLine($"Failed to delete profile {profileId}: {deleteEx.Message}");
+                    logger.LogWarning(deleteEx, "Failed to delete profile {ProfileId}.", profileId);
                 }
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -29,13 +29,27 @@ class Program
 
         using var gpm = new GPM_API(settings.Gpm.BaseUrl);
 
+        int apiRetries = Math.Max(1, settings.Gpm.ApiRetryAttempts);
+        var initialDelay = TimeSpan.FromMilliseconds(Math.Max(0, settings.Gpm.ApiRetryInitialDelayMs));
+        var configuredMaxDelayMs = Math.Max(0, settings.Gpm.ApiRetryMaxDelayMs);
+        var maxDelay = TimeSpan.FromMilliseconds(Math.Max(initialDelay.TotalMilliseconds, configuredMaxDelayMs));
+        if (maxDelay == TimeSpan.Zero)
+        {
+            maxDelay = TimeSpan.FromMilliseconds(1000);
+        }
+
         string? profileId = null;
         StartProfileResponse? startResponse = null;
 
         try
         {
-            // 1) Fetch rotating proxy
-            ProxyXoayResponse proxy = await gpm.FetchRotatingProxyAsync(settings.Gpm.ProxyApiUrl);
+            // 1) Fetch rotating proxy with retries
+            ProxyXoayResponse proxy = await RetryHelper.ExecuteWithRetryAsync(
+                () => gpm.FetchRotatingProxyAsync(settings.Gpm.ProxyApiUrl),
+                maxAttempts: apiRetries,
+                initialDelay: initialDelay,
+                maxDelay: maxDelay,
+                operationName: "ProxyFetch");
             Console.WriteLine($"HTTP: {proxy.proxyhttp}\nSOCKS5: {proxy.proxysocks5}\nMessage: {proxy.message}");
 
             // 2) Create profile with fetched proxy
@@ -43,7 +57,7 @@ class Program
             var osOptions = profileTemplate.OperatingSystems?.Length > 0
                 ? profileTemplate.OperatingSystems
                 : new[] { profileTemplate.Os };
-            var selectedOs = osOptions[Random.Shared.Next(osOptions.Length)];
+            var selectedOs = osOptions[RandomProvider.Next(0, osOptions.Length)];
 
             var profileRequest = new CreateProfileRequest
             {
@@ -66,7 +80,13 @@ class Program
                 WebrtcMode = profileTemplate.WebrtcMode
             };
 
-            CreateProfileResponse createResp = await gpm.CreateProfileAsync(profileRequest);
+            CreateProfileResponse createResp = await RetryHelper.ExecuteWithRetryAsync(
+                () => gpm.CreateProfileAsync(profileRequest),
+                maxAttempts: apiRetries,
+                initialDelay: initialDelay,
+                maxDelay: maxDelay,
+                operationName: "CreateProfile");
+
             profileId = createResp?.data?.id;
             string? browserVersion = createResp?.data?.browser_version;
             Console.WriteLine($"Created profile id: {profileId}");
@@ -79,47 +99,80 @@ class Program
             }
 
             // 3) Start profile
-            startResponse = await gpm.StartProfileAsync(profileId);
+            startResponse = await RetryHelper.ExecuteWithRetryAsync(
+                () => gpm.StartProfileAsync(profileId),
+                maxAttempts: apiRetries,
+                initialDelay: initialDelay,
+                maxDelay: maxDelay,
+                operationName: "StartProfile");
+
+            if (startResponse?.data == null)
+            {
+                Console.WriteLine("Failed to start profile; start response data was null.");
+                return;
+            }
+
             Console.WriteLine($"Driver path: {startResponse.data.driver_path}");
             Console.WriteLine($"Remote debug address: {startResponse.data.remote_debugging_address}");
 
             // 4) Connect Playwright to remote debugging
             using var playwright = await Playwright.CreateAsync();
             var browser = await PlaywrightHelper.ConnectWithRetryAsync(playwright, startResponse.data.remote_debugging_address);
-            var context = browser.Contexts[0];
+            var context = browser.Contexts.Count > 0 ? browser.Contexts[0] : await browser.NewContextAsync();
             var pages = context.Pages;
             var page = pages.Count > 0 ? pages[0] : await context.NewPageAsync();
 
             //5) Use IpHeyService
-            var ipHeyService = new IpHeyService(page);
-            IpHeyResult ipHeyResult = await ipHeyService.CheckAsync();
-            Console.WriteLine($"Status: {ipHeyResult.Status}");
-            Console.WriteLine($"Browser: {ipHeyResult.Browser}");
-            Console.WriteLine($"Location: {ipHeyResult.Location}");
-            Console.WriteLine($"IP: {ipHeyResult.Ip}");
-            Console.WriteLine($"Hardware: {ipHeyResult.Hardware}");
-            Console.WriteLine($"Software: {ipHeyResult.Software}");
+            try
+            {
+                var ipHeyService = new IpHeyService(page);
+                IpHeyResult ipHeyResult = await ipHeyService.CheckAsync();
+                Console.WriteLine($"Status: {ipHeyResult.Status}");
+                Console.WriteLine($"Browser: {ipHeyResult.Browser}");
+                Console.WriteLine($"Location: {ipHeyResult.Location}");
+                Console.WriteLine($"IP: {ipHeyResult.Ip}");
+                Console.WriteLine($"Hardware: {ipHeyResult.Hardware}");
+                Console.WriteLine($"Software: {ipHeyResult.Software}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[IpHey] Failed to complete check: {ex.Message}");
+            }
 
             //6) Use IpFighterService
-            var ipFighter = new IpFighterService(page);
-            IpFighterResult result = await ipFighter.CheckIpAsync();
-            Console.WriteLine($"ISP: {result.Isp}");
-            Console.WriteLine($"Blacklist: {result.Blacklist}");
-            Console.WriteLine($"Proxy: {result.Proxy}");
-            Console.WriteLine($"WebRTC: {result.WebRTC}");
-            Console.WriteLine($"Score: {result.Score}");
-            Console.WriteLine($"City: {result.City}");
-            Console.WriteLine($"Country: {result.Country}");
-            Console.WriteLine($"Hostname: {result.Hostname}");
-            Console.WriteLine($"DNS: {result.DNS}");
-            Console.WriteLine($"Blacklist Details: {result.BlacklistDetails}");
-            Console.WriteLine($"Blacklist Servers: {result.BlacklistServers}");
+            try
+            {
+                var ipFighter = new IpFighterService(page);
+                IpFighterResult result = await ipFighter.CheckIpAsync();
+                Console.WriteLine($"ISP: {result.Isp}");
+                Console.WriteLine($"Blacklist: {result.Blacklist}");
+                Console.WriteLine($"Proxy: {result.Proxy}");
+                Console.WriteLine($"WebRTC: {result.WebRTC}");
+                Console.WriteLine($"Score: {result.Score}");
+                Console.WriteLine($"City: {result.City}");
+                Console.WriteLine($"Country: {result.Country}");
+                Console.WriteLine($"Hostname: {result.Hostname}");
+                Console.WriteLine($"DNS: {result.DNS}");
+                Console.WriteLine($"Blacklist Details: {result.BlacklistDetails}");
+                Console.WriteLine($"Blacklist Servers: {result.BlacklistServers}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[IpFighter] Failed to complete check: {ex.Message}");
+            }
 
             // --- 7) Use SmartSearch ---
             if (!string.IsNullOrWhiteSpace(settings.Search.SmartSearchKeywordDirectory))
             {
-                var smartSearch = new SmartSearchService(page, browser, settings.Search.SmartSearchKeywordDirectory);
-                await smartSearch.SearchOneRandomKeywordAsync();
+                try
+                {
+                    var smartSearch = new SmartSearchService(page, browser, settings.Search.SmartSearchKeywordDirectory);
+                    await smartSearch.SearchOneRandomKeywordAsync();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[SmartSearch] Failed: {ex.Message}");
+                }
             }
             else
             {
@@ -129,10 +182,17 @@ class Program
             // --- 8) Use GoogleSearchService ---
             if (!string.IsNullOrWhiteSpace(settings.Search.GoogleKeywordDirectory))
             {
-                var googleSearch = new GoogleSearchService(context);
-                var currentPage = await googleSearch.SearchOneRandomKeywordAsync(settings.Search.GoogleKeywordDirectory);
-                var userBehavior = new UserBehavior(currentPage);
-                await userBehavior.RunAsync();
+                try
+                {
+                    var googleSearch = new GoogleSearchService(context);
+                    var currentPage = await googleSearch.SearchOneRandomKeywordAsync(settings.Search.GoogleKeywordDirectory);
+                    var userBehavior = new UserBehavior(currentPage);
+                    await userBehavior.RunAsync();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[GoogleSearch] Failed: {ex.Message}");
+                }
             }
             else
             {
@@ -142,7 +202,7 @@ class Program
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Unhandled error: {ex.Message}\n{ex}");
-            throw;
+            Environment.ExitCode = -1;
         }
         finally
         {

--- a/Services/GPM_API.cs
+++ b/Services/GPM_API.cs
@@ -1,54 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GPM_driver.Models;
 
-namespace GPM_driver.Services
+namespace GPM_driver.Services;
+
+public class GPM_API : IDisposable
 {
-    public class GPM_API : IDisposable
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public GPM_API(string baseUrl)
     {
-        private readonly HttpClient _httpClient;
-        private readonly JsonSerializerOptions _jsonOpts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-
-        // baseUrl e.g. "http://127.0.0.1:19995"
-        public GPM_API(string baseUrl)
-        {
-            _httpClient = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/')) };
-        }
-
-        public async Task<CreateProfileResponse> CreateProfileAsync(object profilePayload)
-        {
-            string json = JsonSerializer.Serialize(profilePayload, _jsonOpts);
-            using var content = new StringContent(json, Encoding.UTF8, "application/json");
-            var resp = await _httpClient.PostAsync("/api/v3/profiles/create", content);
-            string respJson = await resp.Content.ReadAsStringAsync();
-            resp.EnsureSuccessStatusCode();
-            return JsonSerializer.Deserialize<CreateProfileResponse>(respJson, _jsonOpts);
-        }
-
-        // proxyUrl can be absolute (https://proxyxoay.shop/...)
-        public async Task<ProxyXoayResponse> FetchRotatingProxyAsync(string proxyUrl)
-        {
-            var resp = await _httpClient.GetAsync(proxyUrl);
-            string json = await resp.Content.ReadAsStringAsync();
-            resp.EnsureSuccessStatusCode();
-            return JsonSerializer.Deserialize<ProxyXoayResponse>(json, _jsonOpts);
-        }
-
-        public async Task<StartProfileResponse> StartProfileAsync(string profileId)
-        {
-            var resp = await _httpClient.GetAsync($"/api/v3/profiles/start/{profileId}");
-            string json = await resp.Content.ReadAsStringAsync();
-            resp.EnsureSuccessStatusCode();
-            return JsonSerializer.Deserialize<StartProfileResponse>(json, _jsonOpts);
-        }
-
-        public void Dispose() => _httpClient?.Dispose();
+        _httpClient = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/')) };
     }
+
+    public async Task<CreateProfileResponse> CreateProfileAsync(CreateProfileRequest profilePayload)
+    {
+        string json = JsonSerializer.Serialize(profilePayload, _jsonOpts);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var resp = await _httpClient.PostAsync("/api/v3/profiles/create", content);
+        string respJson = await resp.Content.ReadAsStringAsync();
+        resp.EnsureSuccessStatusCode();
+        return JsonSerializer.Deserialize<CreateProfileResponse>(respJson, _jsonOpts)!;
+    }
+
+    public async Task<ProxyXoayResponse> FetchRotatingProxyAsync(string proxyUrl)
+    {
+        var resp = await _httpClient.GetAsync(proxyUrl);
+        string json = await resp.Content.ReadAsStringAsync();
+        resp.EnsureSuccessStatusCode();
+        return JsonSerializer.Deserialize<ProxyXoayResponse>(json, _jsonOpts)!;
+    }
+
+    public async Task<StartProfileResponse> StartProfileAsync(string profileId)
+    {
+        var resp = await _httpClient.GetAsync($"/api/v3/profiles/start/{profileId}");
+        string json = await resp.Content.ReadAsStringAsync();
+        resp.EnsureSuccessStatusCode();
+        return JsonSerializer.Deserialize<StartProfileResponse>(json, _jsonOpts)!;
+    }
+
+    public async Task StopProfileAsync(string profileId)
+    {
+        var resp = await _httpClient.GetAsync($"/api/v3/profiles/stop/{profileId}");
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteProfileAsync(string profileId)
+    {
+        var resp = await _httpClient.DeleteAsync($"/api/v3/profiles/delete/{profileId}");
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public void Dispose() => _httpClient.Dispose();
 }

--- a/Services/GoogleSearchService.cs
+++ b/Services/GoogleSearchService.cs
@@ -13,7 +13,7 @@ namespace GPM_driver.Services
         private IPage _page;
         private MouseHelper _mouseHelper;
         private KeyboardHelper _keyboardHelper;
-        private readonly Random _random = new Random();
+        private readonly Random _random = RandomProvider.Shared;
 
         public GoogleSearchService(IBrowserContext context)
         {

--- a/Services/GoogleSearchService.cs
+++ b/Services/GoogleSearchService.cs
@@ -1,4 +1,6 @@
-﻿using GPM_driver.Helpers;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 using System;
 using System.IO;
@@ -14,23 +16,21 @@ namespace GPM_driver.Services
         private MouseHelper _mouseHelper;
         private KeyboardHelper _keyboardHelper;
         private readonly Random _random = RandomProvider.Shared;
+        private readonly ILogger<GoogleSearchService>? _logger;
 
-        public GoogleSearchService(IBrowserContext context)
+        public GoogleSearchService(IBrowserContext context, ILogger<GoogleSearchService>? logger = null)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
+            _logger = logger;
         }
 
-        /// <summary>
-        /// Ensure we have a usable page. Prefer reuse of an existing page in the context (default tab).
-        /// Only create a new page if none exist or page was closed.
-        /// </summary>
         private async Task<IPage> EnsurePageAsync()
         {
-            // If we already have a valid page, return it
             if (_page != null && !_page.IsClosed)
+            {
                 return _page;
+            }
 
-            // Try to reuse any existing open page in the context (prefer the first one)
             var existing = _context.Pages?.FirstOrDefault(p => !p.IsClosed);
             if (existing != null)
             {
@@ -38,64 +38,110 @@ namespace GPM_driver.Services
             }
             else
             {
-                // Fallback: create a new page only if there is no page to reuse
+                _logger?.LogDebug("No reusable Google page found. Creating a new page instance.");
                 _page = await _context.NewPageAsync();
             }
 
-            // Ensure helpers are bound to the selected page
             _mouseHelper = new MouseHelper(_page);
             _keyboardHelper = new KeyboardHelper(_page);
 
             return _page;
         }
 
-        /// <summary>
-        /// Search a keyword on Google. If current page is already on google.com/.com.vn it will be reused;
-        /// otherwise the method navigates the reused page to Google (chooses .com or .com.vn randomly).
-        /// </summary>
+        public async Task RunWarmupAsync(
+            string keywordFolder,
+            GoogleWarmupSettings warmupSettings,
+            Func<IPage?, Task>? onResultVisited = null)
+        {
+            if (warmupSettings is null)
+            {
+                throw new ArgumentNullException(nameof(warmupSettings));
+            }
+
+            int completed = 0;
+            while (true)
+            {
+                string keyword = await PickRandomKeywordAsync(keywordFolder);
+                await SearchKeywordAsync(keyword);
+                var visitedPage = await PersonaClickRandomResultAsync();
+
+                if (visitedPage != null && onResultVisited != null)
+                {
+                    await onResultVisited(visitedPage);
+                }
+
+                completed++;
+                bool underMax = completed < warmupSettings.MaxSearches;
+                if (!underMax)
+                {
+                    _logger?.LogInformation("Reached configured maximum of {Completed} Google warmup searches.", completed);
+                    break;
+                }
+
+                if (completed < warmupSettings.MinSearches)
+                {
+                    _logger?.LogInformation(
+                        "Completed {Completed} Google searches but minimum is {Minimum}. Continuing warmup.",
+                        completed,
+                        warmupSettings.MinSearches);
+                    await PrepareForNextSearchAsync(warmupSettings);
+                    continue;
+                }
+
+                double roll = _random.NextDouble();
+                if (roll >= warmupSettings.ContinueProbability)
+                {
+                    _logger?.LogInformation(
+                        "Ending Google warmup after {Completed} searches (roll={Roll:0.00} threshold={Threshold:0.00}).",
+                        completed,
+                        roll,
+                        warmupSettings.ContinueProbability);
+                    break;
+                }
+
+                _logger?.LogInformation(
+                    "Continuing Google warmup after {Completed} searches (roll={Roll:0.00}).",
+                    completed,
+                    roll);
+                await PrepareForNextSearchAsync(warmupSettings);
+            }
+        }
+
         public async Task SearchKeywordAsync(string keyword)
         {
             if (string.IsNullOrWhiteSpace(keyword))
+            {
                 throw new ArgumentException("keyword must not be empty", nameof(keyword));
+            }
 
             var page = await EnsurePageAsync();
-            Console.WriteLine($"[GoogleSearch] Starting search for: {keyword}");
+            _logger?.LogInformation("Starting Google search for '{Keyword}'.", keyword);
 
-            // If current page is not Google (or is blank), navigate to Google (random .com / .com.vn)
             var curUrl = (page.Url ?? string.Empty).ToLowerInvariant();
-            bool alreadyOnGoogle = curUrl.Contains("google.com") || curUrl.Contains("google.com.vn");
+            bool alreadyOnGoogle = IsOnGoogle(curUrl);
 
             if (!alreadyOnGoogle)
             {
-                string[] domains = { "https://www.google.com", "https://www.google.com.vn" };
-                string url = domains[_random.Next(domains.Length)];
-                Console.WriteLine($"[GoogleSearch] Current url is '{curUrl}'. Navigating to {url}");
-                await page.GotoAsync(url, new PageGotoOptions { Timeout = 60000, WaitUntil = WaitUntilState.DOMContentLoaded });
+                string target = ChooseDomain();
+                _logger?.LogInformation("Navigating from '{CurrentUrl}' to '{TargetUrl}' for Google warmup.", curUrl, target);
+                await page.GotoAsync(target, new PageGotoOptions { Timeout = 60000, WaitUntil = WaitUntilState.DOMContentLoaded });
             }
             else
             {
-                Console.WriteLine($"[GoogleSearch] Reusing existing Google page: {curUrl}");
+                _logger?.LogDebug("Reusing existing Google page: {Url}.", curUrl);
             }
 
-            // Wait for the search input to appear
-            var input = page.Locator("//textarea[@id='APjFqb']");
-            await input.WaitForAsync(new LocatorWaitForOptions { Timeout = 30000 });
-
-            // Move to input and focus/click
+            var input = await EnsureSearchInputAsync();
             await _mouseHelper.MoveAndClickAsync(input);
-
-            // Type keyword like human
+            await ClearSearchBoxAsync(input);
             await _keyboard_helper_TypeLikeHumanAsync(input, keyword);
 
-            // small natural pause
             await Task.Delay(_random.Next(500, 2001));
 
-            // Choose search action (suggestion / arrowdown / click btnK / Enter)
             double choice = _random.NextDouble();
 
             if (choice < 0.25)
             {
-                // Click suggestion if present
                 var suggestions = page.Locator("//*[@id='Alh6id']/div[1]/div/ul/li");
                 int count = await suggestions.CountAsync();
                 if (count > 0)
@@ -104,170 +150,302 @@ namespace GPM_driver.Services
                     var suggestion = page.Locator($"//*[@id='Alh6id']/div[1]/div/ul/li[{index}]");
                     await Task.Delay(_random.Next(500, 2001));
                     await _mouseHelper.MoveAndClickAsync(suggestion);
-                    Console.WriteLine($"[GoogleSearch] Clicked suggestion #{index}");
+                    _logger?.LogInformation("Clicked Google suggestion #{Index}.", index);
                     return;
                 }
-                else
-                {
-                    await input.PressAsync("Enter");
-                    Console.WriteLine("[GoogleSearch] No suggestions, pressed Enter.");
-                    return;
-                }
+
+                await input.PressAsync("Enter");
+                _logger?.LogInformation("No suggestions available; pressed Enter.");
+                return;
             }
-            else if (choice < 0.5)
+
+            if (choice < 0.5)
             {
-                // ArrowDown selecting based on suggestion count
                 var suggestions = page.Locator("//*[@id='Alh6id']/div[1]/div/ul/li");
                 int count = await suggestions.CountAsync();
-                if (count > 0)
+                int times = count > 0 ? _random.Next(1, count + 1) : _random.Next(1, 4);
+                for (int i = 0; i < times; i++)
                 {
-                    int times = _random.Next(1, count + 1);
-                    for (int i = 0; i < times; i++)
-                    {
-                        await input.PressAsync("ArrowDown");
-                        await Task.Delay(_random.Next(50, 501));
-                    }
-                    await input.PressAsync("Enter");
-                    Console.WriteLine($"[GoogleSearch] ArrowDown {times} times, then Enter.");
-                    return;
+                    await input.PressAsync("ArrowDown");
+                    await Task.Delay(_random.Next(50, 501));
                 }
-                else
-                {
-                    // fallback behavior
-                    int fallback = _random.Next(1, 4);
-                    for (int i = 0; i < fallback; i++)
-                    {
-                        await input.PressAsync("ArrowDown");
-                        await Task.Delay(_random.Next(50, 501));
-                    }
-                    await input.PressAsync("Enter");
-                    Console.WriteLine($"[GoogleSearch] No suggestions; ArrowDown x{fallback} then Enter.");
-                    return;
-                }
+                await input.PressAsync("Enter");
+                _logger?.LogInformation("Pressed ArrowDown {Times} times then Enter.", times);
+                return;
             }
-            else if (choice < 0.75)
+
+            if (choice < 0.75)
             {
-                // Click btnK if visible
                 var searchBtn = page.Locator("//div[@class='lJ9FBc']//input[@name='btnK']");
                 if (await searchBtn.CountAsync() > 0 && await searchBtn.IsVisibleAsync())
                 {
                     await Task.Delay(_random.Next(500, 2001));
                     await _mouseHelper.MoveAndClickAsync(searchBtn);
-                    Console.WriteLine("[GoogleSearch] Clicked search button (btnK).");
+                    _logger?.LogInformation("Clicked Google search button (btnK).");
                     return;
                 }
-                else
-                {
-                    await input.PressAsync("Enter");
-                    Console.WriteLine("[GoogleSearch] btnK not visible; pressed Enter.");
-                    return;
-                }
-            }
-            else
-            {
-                // Press Enter directly
+
                 await input.PressAsync("Enter");
-                Console.WriteLine("[GoogleSearch] Pressed Enter.");
+                _logger?.LogInformation("Search button unavailable; pressed Enter.");
                 return;
             }
+
+            await input.PressAsync("Enter");
+            _logger?.LogInformation("Pressed Enter to execute Google search.");
         }
-        /// <summary>
-        /// Persona-driven: optionally scroll, then click a random search result.
-        /// </summary>
+
         public async Task<IPage?> PersonaClickRandomResultAsync()
         {
             var page = await EnsurePageAsync();
 
-            // Wait for results
             var resultsLocator = page.Locator("//div[@class='yuRUbf']");
             await resultsLocator.First.WaitForAsync(new LocatorWaitForOptions { Timeout = 10000 });
 
             int maxSites = await resultsLocator.CountAsync();
             if (maxSites == 0)
             {
-                Console.WriteLine("[GoogleSearch] No search results found.");
+                _logger?.LogWarning("No Google search results found to click.");
                 return null;
             }
 
-            // Persona decision: scroll before clicking?
             double decision = _random.NextDouble();
             if (decision < 0.3)
             {
-                // 30% chance: scroll randomly
                 int bursts = _random.Next(1, 4);
                 await ScrollHelper.ScrollRandomAsync(page, bursts);
-                Console.WriteLine($"[GoogleSearch] Persona scrolled randomly ({bursts} bursts).");
+                _logger?.LogInformation("Persona scrolled randomly ({Bursts} bursts) before clicking.", bursts);
             }
             else if (decision < 0.5)
             {
-                // 20% chance: scroll to bottom
                 await ScrollHelper.ScrollToBottomAsync(page);
-                Console.WriteLine("[GoogleSearch] Persona scrolled to bottom.");
+                _logger?.LogInformation("Persona scrolled to the bottom before selecting a result.");
             }
             else
             {
-                // 50% chance: no scroll
-                Console.WriteLine("[GoogleSearch] Persona did not scroll before clicking.");
+                _logger?.LogDebug("Persona chose not to scroll before clicking.");
             }
 
-            // Pick target link
             int targetIndex = _random.Next(1, maxSites + 1);
             var targetSite = page.Locator($"(//div[@class='yuRUbf']//a[@jsname='UWckNb'])[{targetIndex}]");
-            Console.WriteLine($"[GoogleSearch] Clicking result #{targetIndex} of {maxSites}");
+            _logger?.LogInformation("Clicking Google result #{Index} of {Total}.", targetIndex, maxSites);
 
-            // Scroll into viewport if needed
             await ScrollHelper.ScrollToElementAsync(page, targetSite);
 
-            // Try click (with retry on misfire)
             try
             {
                 await _mouseHelper.MoveAndClickAsync(targetSite);
             }
-            catch
+            catch (Exception ex)
             {
-                Console.WriteLine("[GoogleSearch] First click failed, retrying...");
+                _logger?.LogDebug(ex, "First click on result #{Index} failed, retrying.", targetIndex);
                 await Task.Delay(_random.Next(500, 1500));
                 await _mouseHelper.MoveAndClickAsync(targetSite);
             }
 
-            // Wait for navigation
             await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-
-            Console.WriteLine("[GoogleSearch] Navigation complete.");
+            _logger?.LogInformation("Navigation to selected result completed.");
             return page;
-        }   
-        /// <summary>
-        /// Convenience wrapper: pick one random keyword from keywordFolder and run SearchKeywordAsync.
-        /// Returns the current page after navigation (may be different from original).
-        /// </summary>
+        }
+
         public async Task<IPage> SearchOneRandomKeywordAsync(string keywordFolder)
         {
-            if (!Directory.Exists(keywordFolder))
-                throw new DirectoryNotFoundException($"Keyword folder not found: {keywordFolder}");
-
-            string[] files = Directory.GetFiles(keywordFolder, "*.txt");
-            if (files.Length == 0)
-                throw new FileNotFoundException("No keyword files in folder.");
-
-            // pick random file and random non-empty line
-            string file = files[_random.Next(files.Length)];
-            var lines = (await File.ReadAllLinesAsync(file)).Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
-            if (lines.Length == 0) throw new InvalidOperationException("Keyword file empty.");
-
-            string keyword = lines[_random.Next(lines.Length)].Trim();
+            string keyword = await PickRandomKeywordAsync(keywordFolder);
             await SearchKeywordAsync(keyword);
             var currentPage = await PersonaClickRandomResultAsync();
-            
-            // Return the current page (which might be the navigated page)
             return currentPage ?? _page;
         }
 
-        // Small local wrapper to use KeyboardHelper (keeps class independent if helper changes)
+        public async Task<string> PickRandomKeywordAsync(string keywordFolder)
+        {
+            if (!Directory.Exists(keywordFolder))
+            {
+                throw new DirectoryNotFoundException($"Keyword folder not found: {keywordFolder}");
+            }
+
+            string[] files = Directory.GetFiles(keywordFolder, "*.txt");
+            if (files.Length == 0)
+            {
+                throw new FileNotFoundException("No keyword files in folder.", keywordFolder);
+            }
+
+            string file = files[_random.Next(files.Length)];
+            var lines = (await File.ReadAllLinesAsync(file)).Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+            if (lines.Length == 0)
+            {
+                throw new InvalidOperationException($"Keyword file '{file}' is empty.");
+            }
+
+            string keyword = lines[_random.Next(lines.Length)].Trim();
+            _logger?.LogDebug("Selected keyword '{Keyword}' from '{FileName}'.", keyword, Path.GetFileName(file));
+            return keyword;
+        }
+
+        public async Task PrepareForNextSearchAsync(GoogleWarmupSettings warmupSettings)
+        {
+            var page = await EnsurePageAsync();
+
+            await Task.Delay(_random.Next(1500, 4000));
+            double strategy = _random.NextDouble();
+
+            if (strategy < 0.35)
+            {
+                string domain = ChooseDomain(warmupSettings);
+                _logger?.LogInformation("Warmup navigating directly to {Domain} for next keyword.", domain);
+                await page.GotoAsync(domain, new PageGotoOptions { Timeout = 60000, WaitUntil = WaitUntilState.DOMContentLoaded });
+                await Task.Delay(_random.Next(500, 1500));
+                var input = await EnsureSearchInputAsync();
+                await _mouseHelper.MoveAndClickAsync(input);
+                await ClearSearchBoxAsync(input);
+                return;
+            }
+
+            bool returned = await TryReturnToGoogleAsync(warmupSettings);
+            if (!returned)
+            {
+                string fallbackDomain = ChooseDomain(warmupSettings);
+                _logger?.LogInformation("Browser history lacked Google page. Navigating to {Domain}.", fallbackDomain);
+                await page.GotoAsync(fallbackDomain, new PageGotoOptions { Timeout = 60000, WaitUntil = WaitUntilState.DOMContentLoaded });
+            }
+
+            bool useSlashShortcut = strategy < 0.7;
+            var focusLocator = await FocusSearchInputAsync(useSlashShortcut);
+            await ClearSearchBoxAsync(focusLocator);
+        }
+
+        private async Task<bool> TryReturnToGoogleAsync(GoogleWarmupSettings warmupSettings)
+        {
+            var page = await EnsurePageAsync();
+            int maxAttempts = Math.Max(1, warmupSettings.MaxBacktracks);
+
+            for (int attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                if (IsOnGoogle(page.Url))
+                {
+                    return true;
+                }
+
+                var response = await page.GoBackAsync(new PageGoBackOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 60000 });
+                await Task.Delay(_random.Next(500, 1500));
+
+                if (response == null && !IsOnGoogle(page.Url))
+                {
+                    break;
+                }
+            }
+
+            return IsOnGoogle(page.Url);
+        }
+
+        private async Task<ILocator> FocusSearchInputAsync(bool useSlashShortcut)
+        {
+            var page = await EnsurePageAsync();
+
+            if (useSlashShortcut)
+            {
+                _logger?.LogDebug("Focusing Google search via '/' shortcut.");
+                await page.Keyboard.PressAsync("/");
+                await Task.Delay(_random.Next(200, 600));
+            }
+
+            var input = await EnsureSearchInputAsync();
+
+            bool isFocused = false;
+            try
+            {
+                isFocused = await input.IsFocusedAsync();
+            }
+            catch
+            {
+                isFocused = false;
+            }
+
+            if (!isFocused)
+            {
+                _logger?.LogDebug("Search input not focused; clicking element.");
+                await _mouseHelper.MoveAndClickAsync(input);
+            }
+
+            return input;
+        }
+
+        private async Task<ILocator> EnsureSearchInputAsync()
+        {
+            var page = await EnsurePageAsync();
+            var locator = page.Locator("//textarea[@id='APjFqb']");
+            if (await locator.CountAsync() == 0)
+            {
+                locator = page.Locator("input[name='q']");
+            }
+
+            await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = 30000 });
+            return locator;
+        }
+
+        private async Task ClearSearchBoxAsync(ILocator input)
+        {
+            string currentValue = string.Empty;
+            try
+            {
+                currentValue = await input.InputValueAsync() ?? string.Empty;
+            }
+            catch
+            {
+                currentValue = string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(currentValue))
+            {
+                return;
+            }
+
+            bool useSelectAll = _random.NextDouble() < 0.65;
+            if (useSelectAll)
+            {
+                _logger?.LogDebug("Clearing existing query using Ctrl+A.");
+                await _page.Keyboard.PressAsync("Control+A");
+                await Task.Delay(_random.Next(100, 300));
+                string key = _random.NextDouble() < 0.5 ? "Backspace" : "Delete";
+                await _page.Keyboard.PressAsync(key);
+            }
+            else
+            {
+                _logger?.LogDebug("Clearing existing query using backspace strokes.");
+                await _keyboardHelper.BackspaceAsync(currentValue.Length, fastCorrection: true);
+            }
+
+            await Task.Delay(_random.Next(200, 500));
+        }
+
+        private static bool IsOnGoogle(string? url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return false;
+            }
+
+            return url.Contains("google.com", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private string ChooseDomain(GoogleWarmupSettings? warmupSettings = null)
+        {
+            string[] domains = warmupSettings?.Domains?.Length > 0
+                ? warmupSettings.Domains
+                : new[] { "https://www.google.com", "https://www.google.com.vn" };
+
+            return domains[_random.Next(domains.Length)];
+        }
+
+        private string ChooseDomain()
+        {
+            return ChooseDomain(null);
+        }
+
         private async Task _keyboard_helper_TypeLikeHumanAsync(ILocator locator, string text)
         {
-            // Ensure keyboard helper exists (EnsurePageAsync has already initialized it)
             if (_keyboardHelper == null)
+            {
                 _keyboardHelper = new KeyboardHelper(_page);
+            }
 
             await _keyboardHelper.TypeLikeHumanAsync(locator, text);
         }

--- a/Services/GoogleSearchService.cs
+++ b/Services/GoogleSearchService.cs
@@ -352,7 +352,7 @@ namespace GPM_driver.Services
             bool isFocused = false;
             try
             {
-                isFocused = await input.IsFocusedAsync();
+                isFocused = await input.EvaluateAsync<bool>("el => document.activeElement === el");
             }
             catch
             {

--- a/Services/IpFighterService.cs
+++ b/Services/IpFighterService.cs
@@ -6,16 +6,19 @@ using System.Threading.Tasks;
 using Microsoft.Playwright;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
 
 namespace GPM_driver.Services
 {
     public class IpFighterService
     {
         private readonly IPage _page;
+        private readonly ILogger<IpFighterService>? _logger;
 
-        public IpFighterService(IPage page)
+        public IpFighterService(IPage page, ILogger<IpFighterService>? logger = null)
         {
             _page = page;
+            _logger = logger;
         }
 
         public async Task<IpFighterResult> CheckIpAsync()
@@ -87,7 +90,7 @@ namespace GPM_driver.Services
             }
         }
 
-        private static async Task<bool> TryClickAsync(ILocator locator)
+        private async Task<bool> TryClickAsync(ILocator locator)
         {
             try
             {
@@ -96,19 +99,21 @@ namespace GPM_driver.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[IpFighterService] Failed to click {await DescribeAsync(locator)}: {ex.Message}");
+                var description = await DescribeAsync(locator);
+                _logger?.LogWarning(ex, "IpFighter failed to click {LocatorDescription}", description);
                 return false;
             }
         }
 
-        private static async Task<string> DescribeAsync(ILocator locator)
+        private async Task<string> DescribeAsync(ILocator locator)
         {
             try
             {
                 return await locator.EvaluateAsync<string>("el => el.outerHTML") ?? locator.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger?.LogDebug(ex, "Failed to describe locator; falling back to ToString().");
                 return locator.ToString();
             }
         }

--- a/Services/IpFighterService.cs
+++ b/Services/IpFighterService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
+using GPM_driver.Helpers;
 using GPM_driver.Models;
 
 namespace GPM_driver.Services
@@ -21,38 +22,95 @@ namespace GPM_driver.Services
         {
             await _page.GotoAsync("https://ipfighter.com/vi", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 60000 });
             // Add random delay between 5-10 seconds
-            var random = new Random();
-            var delayMilliseconds = random.Next(10001, 16000); // 5000ms to 10000ms (5-10 seconds)
+            var delayMilliseconds = RandomProvider.Next(5000, 10001);
             await Task.Delay(delayMilliseconds);
 
             var result = new IpFighterResult
             {
-                Isp = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(5) > div > b").InnerTextAsync(),
-                Blacklist = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(10) > div > div").InnerTextAsync(),
-                Proxy = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(9) > div > div").InnerTextAsync(),
-                WebRTC = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(7) > div > div").InnerTextAsync(),
-                Score = await _page.Locator(".CircularProgressbar-text").TextContentAsync() ?? "",
-                City = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(2) > div > b").InnerTextAsync(),
-                Country = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(1) > div > b").InnerTextAsync(),
-                Hostname = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(4) > div > b").InnerTextAsync(),
-                DNS = await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(6) > div > div").InnerTextAsync()
+                Isp = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(5) > div > b")),
+                Blacklist = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(10) > div > div")),
+                Proxy = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(9) > div > div")),
+                WebRTC = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(7) > div > div")),
+                Score = await TryReadTextContentAsync(_page.Locator(".CircularProgressbar-text")),
+                City = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(2) > div > b")),
+                Country = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(1) > div > b")),
+                Hostname = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(4) > div > b")),
+                BlacklistDetails = string.Empty,
+                BlacklistServers = string.Empty,
             };
+            result.DNS = await TryReadInnerTextAsync(_page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_ipInfo__7AV_Z > div:nth-child(6) > div > div"));
 
             // Click “More” then get blacklist details
-            await _page.GetByRole(AriaRole.Button, new() { Name = "More" }).ClickAsync();
-            await _page.Locator("div.home_detailRateScore__RD62j").WaitForAsync();
-            result.BlacklistDetails = await _page.Locator(
-                "#__next > div.home_boxBig__DT6_C > div.containerr > div.home_detailRateScore__RD62j > div > div.home_itemScore__Jrnyw.align-items-start > div.home_content__iZ3a6"
-            ).InnerTextAsync();
+            if (await TryClickAsync(_page.GetByRole(AriaRole.Button, new() { Name = "More" })))
+            {
+                await _page.Locator("div.home_detailRateScore__RD62j").WaitForAsync(new() { Timeout = 5000 });
+                result.BlacklistDetails = await TryReadInnerTextAsync(
+                    _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_detailRateScore__RD62j > div > div.home_itemScore__Jrnyw.align-items-start > div.home_content__iZ3a6")
+                );
+            }
 
             // Click “Show” then get blacklist servers
-            await _page.GetByRole(AriaRole.Button, new() { Name = "Show" }).ClickAsync();
-            await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_detailRateScore__RD62j > div > div:nth-child(2)").WaitForAsync();
-            result.BlacklistServers = await _page.Locator(
-                "#__next > div.home_boxBig__DT6_C > div.containerr > div.home_detailRateScore__RD62j > div > div:nth-child(2)"
-            ).InnerTextAsync();
+            if (await TryClickAsync(_page.GetByRole(AriaRole.Button, new() { Name = "Show" })))
+            {
+                await _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_detailRateScore__RD62j > div > div:nth-child(2)").WaitForAsync(new() { Timeout = 5000 });
+                result.BlacklistServers = await TryReadInnerTextAsync(
+                    _page.Locator("#__next > div.home_boxBig__DT6_C > div.containerr > div.home_detailRateScore__RD62j > div > div:nth-child(2)")
+                );
+            }
 
             return result;
+        }
+
+        private static async Task<string> TryReadInnerTextAsync(ILocator locator, string defaultValue = "")
+        {
+            try
+            {
+                await locator.WaitForAsync(new() { Timeout = 5000 });
+                return await locator.InnerTextAsync() ?? defaultValue;
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
+
+        private static async Task<string> TryReadTextContentAsync(ILocator locator, string defaultValue = "")
+        {
+            try
+            {
+                await locator.WaitForAsync(new() { Timeout = 5000 });
+                return await locator.TextContentAsync() ?? defaultValue;
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
+
+        private static async Task<bool> TryClickAsync(ILocator locator)
+        {
+            try
+            {
+                await locator.ClickAsync(new() { Timeout = 5000 });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[IpFighterService] Failed to click {await DescribeAsync(locator)}: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static async Task<string> DescribeAsync(ILocator locator)
+        {
+            try
+            {
+                return await locator.EvaluateAsync<string>("el => el.outerHTML") ?? locator.ToString();
+            }
+            catch
+            {
+                return locator.ToString();
+            }
         }
     }
 }

--- a/Services/IpHeyChecker.cs
+++ b/Services/IpHeyChecker.cs
@@ -6,16 +6,19 @@ using System.Threading.Tasks;
 using Microsoft.Playwright;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
 
 namespace GPM_driver.Services
 {
     public class IpHeyService
     {
         private readonly IPage _page;
+        private readonly ILogger<IpHeyService>? _logger;
 
-        public IpHeyService(IPage page)
+        public IpHeyService(IPage page, ILogger<IpHeyService>? logger = null)
         {
             _page = page;
+            _logger = logger;
         }
 
         public async Task<IpHeyResult> CheckAsync()
@@ -47,7 +50,7 @@ namespace GPM_driver.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[IpHeyService] Failed to read locator: {ex.Message}");
+                _logger?.LogWarning(ex, "IpHey locator read failed.");
                 return fallback;
             }
         }

--- a/Services/IpHeyChecker.cs
+++ b/Services/IpHeyChecker.cs
@@ -41,7 +41,7 @@ namespace GPM_driver.Services
             };
         }
 
-        private static async Task<string> TryInnerTextAsync(ILocator locator, string fallback = "")
+        private async Task<string> TryInnerTextAsync(ILocator locator, string fallback = "")
         {
             try
             {

--- a/Services/IpHeyChecker.cs
+++ b/Services/IpHeyChecker.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
-using System.Threading.Tasks;
+using GPM_driver.Helpers;
 using GPM_driver.Models;
 
 namespace GPM_driver.Services
@@ -23,23 +23,33 @@ namespace GPM_driver.Services
             await _page.GotoAsync("https://iphey.com", new PageGotoOptions { Timeout = 60000, WaitUntil = WaitUntilState.DOMContentLoaded });
             //await _page.GotoAsync("https://iphey.com", new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
             //await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            await _page.Locator(".identity-status__status:not(.hide) span").WaitForAsync();
-            // Add random delay between 5-10 seconds
-            var random = new Random();
-            var delayMilliseconds = random.Next(20000, 30000); // 5000ms to 10000ms (5-10 seconds)
-            await Task.Delay(delayMilliseconds);
+            await _page.Locator(".identity-status__status:not(.hide) span").WaitForAsync(new() { Timeout = 60000 });
+            // Add random delay between 5-10 seconds to mimic reading
+            await Task.Delay(RandomProvider.Next(5000, 10001));
 
-            var result = new IpHeyResult
+            return new IpHeyResult
             {
-                Status = await _page.Locator(".identity-status__status:not(.hide) span").InnerTextAsync(),
-                Browser = await _page.Locator(".identity-check__item:nth-of-type(1) .identity-check__text").InnerTextAsync(),
-                Location = await _page.Locator(".identity-check__item:nth-of-type(2) .identity-check__text").InnerTextAsync(),
-                Ip = await _page.Locator(".identity-check__item:nth-of-type(3) .identity-check__text").InnerTextAsync(),
-                Hardware = await _page.Locator(".identity-check__item:nth-of-type(4) .identity-check__text").InnerTextAsync(),
-                Software = await _page.Locator(".identity-check__item:nth-of-type(5) .identity-check__text").InnerTextAsync()
+                Status = await TryInnerTextAsync(_page.Locator(".identity-status__status:not(.hide) span")),
+                Browser = await TryInnerTextAsync(_page.Locator(".identity-check__item:nth-of-type(1) .identity-check__text")),
+                Location = await TryInnerTextAsync(_page.Locator(".identity-check__item:nth-of-type(2) .identity-check__text")),
+                Ip = await TryInnerTextAsync(_page.Locator(".identity-check__item:nth-of-type(3) .identity-check__text")),
+                Hardware = await TryInnerTextAsync(_page.Locator(".identity-check__item:nth-of-type(4) .identity-check__text")),
+                Software = await TryInnerTextAsync(_page.Locator(".identity-check__item:nth-of-type(5) .identity-check__text"))
             };
+        }
 
-            return result;
+        private static async Task<string> TryInnerTextAsync(ILocator locator, string fallback = "")
+        {
+            try
+            {
+                await locator.WaitForAsync(new() { Timeout = 5000 });
+                return await locator.InnerTextAsync() ?? fallback;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[IpHeyService] Failed to read locator: {ex.Message}");
+                return fallback;
+            }
         }
     }
 }

--- a/Services/SmartSearchService.cs
+++ b/Services/SmartSearchService.cs
@@ -14,7 +14,7 @@ namespace GPM_driver.Services
         private readonly IPage _page;
         private readonly IBrowser _browser;
         private readonly string _keywordFolder;
-        private readonly Random _random = new Random();
+        private readonly Random _random = RandomProvider.Shared;
 
         public SmartSearchService(IPage page, IBrowser browser, string keywordFolder = @"E:\Google_Farm\google\")
         {

--- a/Services/WarmupSession.cs
+++ b/Services/WarmupSession.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GPM_driver.Behaviors;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services;
+
+internal class WarmupSession
+{
+    private readonly AppSettings _settings;
+    private readonly IBrowser _browser;
+    private readonly IBrowserContext _context;
+    private readonly ILogger<WarmupSession> _logger;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public WarmupSession(
+        AppSettings settings,
+        IBrowser browser,
+        IBrowserContext context,
+        ILogger<WarmupSession> logger,
+        ILoggerFactory loggerFactory)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _browser = browser ?? throw new ArgumentNullException(nameof(browser));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+    }
+
+    public async Task RunAsync()
+    {
+        var page = await EnsurePrimaryPageAsync();
+
+        await RunIpChecksAsync(page);
+        await RunSmartSearchAsync(page);
+        await RunGoogleWarmupAsync();
+    }
+
+    private async Task<IPage> EnsurePrimaryPageAsync()
+    {
+        var page = _context.Pages.FirstOrDefault(p => !p.IsClosed);
+        if (page != null)
+        {
+            return page;
+        }
+
+        _logger.LogDebug("No existing page available, opening a new tab for warmup.");
+        page = await _context.NewPageAsync();
+        return page;
+    }
+
+    private async Task RunIpChecksAsync(IPage page)
+    {
+        try
+        {
+            var ipHeyLogger = _loggerFactory.CreateLogger<IpHeyService>();
+            var ipHeyService = new IpHeyService(page, ipHeyLogger);
+            var ipHeyResult = await ipHeyService.CheckAsync();
+
+            _logger.LogInformation(
+                "IpHey status={Status} browser={Browser} location={Location} ip={Ip}",
+                ipHeyResult.Status,
+                ipHeyResult.Browser,
+                ipHeyResult.Location,
+                ipHeyResult.Ip);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "IpHey warmup check failed.");
+        }
+
+        try
+        {
+            var ipFighterLogger = _loggerFactory.CreateLogger<IpFighterService>();
+            var ipFighterService = new IpFighterService(page, ipFighterLogger);
+            var ipResult = await ipFighterService.CheckIpAsync();
+
+            _logger.LogInformation(
+                "IpFighter isp={Isp} blacklist={Blacklist} proxy={Proxy} score={Score}",
+                ipResult.Isp,
+                ipResult.Blacklist,
+                ipResult.Proxy,
+                ipResult.Score);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "IpFighter warmup check failed.");
+        }
+    }
+
+    private async Task RunSmartSearchAsync(IPage page)
+    {
+        var keywordDirectory = _settings.Search.SmartSearchKeywordDirectory;
+        if (string.IsNullOrWhiteSpace(keywordDirectory))
+        {
+            _logger.LogInformation("SmartSearch keyword directory not configured. Skipping SmartSearch warmup.");
+            return;
+        }
+
+        if (!Directory.Exists(keywordDirectory))
+        {
+            _logger.LogWarning("SmartSearch keyword directory '{Directory}' does not exist.", keywordDirectory);
+            return;
+        }
+
+        try
+        {
+            var smartSearch = new SmartSearchService(page, _browser, keywordDirectory);
+            await smartSearch.SearchOneRandomKeywordAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "SmartSearch warmup failed.");
+        }
+    }
+
+    private async Task RunGoogleWarmupAsync()
+    {
+        var keywordDirectory = _settings.Search.GoogleKeywordDirectory;
+        if (string.IsNullOrWhiteSpace(keywordDirectory))
+        {
+            _logger.LogInformation("Google keyword directory not configured. Skipping Google warmup.");
+            return;
+        }
+
+        if (!Directory.Exists(keywordDirectory))
+        {
+            _logger.LogWarning("Google keyword directory '{Directory}' does not exist.", keywordDirectory);
+            return;
+        }
+
+        var warmupConfig = _settings.Search.GoogleWarmup ?? new GoogleWarmupSettings();
+        if (warmupConfig.MinSearches < 1)
+        {
+            warmupConfig.MinSearches = 1;
+        }
+        if (warmupConfig.MaxSearches < warmupConfig.MinSearches)
+        {
+            warmupConfig.MaxSearches = warmupConfig.MinSearches;
+        }
+
+        var googleLogger = _loggerFactory.CreateLogger<GoogleSearchService>();
+        var googleSearch = new GoogleSearchService(_context, googleLogger);
+
+        try
+        {
+            await googleSearch.RunWarmupAsync(
+                keywordDirectory,
+                warmupConfig,
+                async visitedPage =>
+                {
+                    if (visitedPage == null)
+                    {
+                        return;
+                    }
+
+                    var userBehavior = new UserBehavior(visitedPage);
+                    await userBehavior.RunAsync();
+                });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Google warmup failed.");
+        }
+    }
+}

--- a/Services/WarmupSession.cs
+++ b/Services/WarmupSession.cs
@@ -17,19 +17,22 @@ internal class WarmupSession
     private readonly IBrowserContext _context;
     private readonly ILogger<WarmupSession> _logger;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly string? _profileId;
 
     public WarmupSession(
         AppSettings settings,
         IBrowser browser,
         IBrowserContext context,
         ILogger<WarmupSession> logger,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        string? profileId)
     {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _browser = browser ?? throw new ArgumentNullException(nameof(browser));
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _profileId = profileId;
     }
 
     public async Task RunAsync()
@@ -191,7 +194,7 @@ internal class WarmupSession
 
         try
         {
-            await youtubeWarmup.RunWarmupAsync(keywordDirectory, warmupConfig);
+            await youtubeWarmup.RunWarmupAsync(keywordDirectory, warmupConfig, _profileId);
         }
         catch (Exception ex)
         {

--- a/Services/WarmupSession.cs
+++ b/Services/WarmupSession.cs
@@ -39,6 +39,7 @@ internal class WarmupSession
         await RunIpChecksAsync(page);
         await RunSmartSearchAsync(page);
         await RunGoogleWarmupAsync();
+        await RunYouTubeWarmupAsync();
     }
 
     private async Task<IPage> EnsurePrimaryPageAsync()
@@ -166,6 +167,35 @@ internal class WarmupSession
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Google warmup failed.");
+        }
+    }
+
+    private async Task RunYouTubeWarmupAsync()
+    {
+        var warmupConfig = _settings.Search.YouTubeWarmup;
+        if (warmupConfig == null || !warmupConfig.Enabled)
+        {
+            _logger.LogInformation("YouTube warmup disabled or not configured. Skipping.");
+            return;
+        }
+
+        var keywordDirectory = _settings.Search.YouTubeKeywordDirectory;
+        if (!string.IsNullOrWhiteSpace(keywordDirectory) && !Directory.Exists(keywordDirectory))
+        {
+            _logger.LogWarning("YouTube keyword directory '{Directory}' does not exist. Falling back to built-in keywords.", keywordDirectory);
+            keywordDirectory = null;
+        }
+
+        var ytLogger = _loggerFactory.CreateLogger<YouTubeWarmupService>();
+        var youtubeWarmup = new YouTubeWarmupService(_context, ytLogger);
+
+        try
+        {
+            await youtubeWarmup.RunWarmupAsync(keywordDirectory, warmupConfig);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "YouTube warmup failed.");
         }
     }
 }

--- a/Services/YouTube/HomeInteractionService.cs
+++ b/Services/YouTube/HomeInteractionService.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class HomeInteractionService
+{
+    private readonly Func<Task<IPage>> _ensurePage;
+    private readonly Func<YouTubeWarmupSettings, Task> _navigateHomeAsync;
+    private readonly VideoPlayerService _videoPlayer;
+    private readonly RecommendationChainService _recommendationChain;
+    private readonly Func<IPage, string, Task> _waitForNavigationAsync;
+    private readonly Random _random;
+    private readonly Func<MouseHelper?> _mouseProvider;
+    private readonly ILogger? _logger;
+
+    public HomeInteractionService(
+        Func<Task<IPage>> ensurePage,
+        Func<YouTubeWarmupSettings, Task> navigateHomeAsync,
+        VideoPlayerService videoPlayer,
+        RecommendationChainService recommendationChain,
+        Func<IPage, string, Task> waitForNavigationAsync,
+        Random random,
+        Func<MouseHelper?> mouseProvider,
+        ILogger? logger)
+    {
+        _ensurePage = ensurePage;
+        _navigateHomeAsync = navigateHomeAsync;
+        _videoPlayer = videoPlayer;
+        _recommendationChain = recommendationChain;
+        _waitForNavigationAsync = waitForNavigationAsync;
+        _random = random;
+        _mouseProvider = mouseProvider;
+        _logger = logger;
+    }
+
+    public async Task<bool> ExecuteAsync(YouTubeWarmupSettings warmup)
+    {
+        try
+        {
+            var page = await _ensurePage();
+            await _navigateHomeAsync(warmup);
+            await MaybeMisclickMenuAsync(page);
+
+            var richItems = page.Locator("#contents ytd-rich-item-renderer a#thumbnail");
+            int count = await richItems.CountAsync();
+            if (count == 0)
+            {
+                _logger?.LogWarning("No rich items on YouTube home page.");
+                return false;
+            }
+
+            int index = _random.Next(0, count);
+            var target = richItems.Nth(index);
+            var mouse = _mouseProvider();
+            if (mouse != null)
+            {
+                await mouse.MoveAndClickAsync(target);
+            }
+            else
+            {
+                await target.ClickAsync();
+            }
+
+            string beforeClickUrl = page.Url;
+            await _waitForNavigationAsync(page, beforeClickUrl);
+
+            var result = await _videoPlayer.WatchCurrentEntryAsync(
+                warmup,
+                context: "RecommendationHome",
+                method: "HomeRecommendation",
+                contextDetail: $"HomeRecommendation#{index + 1}",
+                entryPoint: "Home",
+                keyword: null,
+                position: index + 1,
+                parent: null);
+            if (result == null)
+            {
+                return false;
+            }
+
+            await _recommendationChain.MaybeChainRecommendedVideosAsync(warmup, result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Home recommendation interaction failed.");
+            return false;
+        }
+    }
+
+    private async Task MaybeMisclickMenuAsync(IPage page)
+    {
+        if (_random.NextDouble() > 0.15)
+        {
+            return;
+        }
+
+        try
+        {
+            var menuItems = page.Locator("ytd-mini-guide-entry-renderer a");
+            int menuCount = await menuItems.CountAsync();
+            if (menuCount == 0)
+            {
+                return;
+            }
+
+            int index = _random.Next(0, Math.Min(menuCount, 4));
+            var target = menuItems.Nth(index);
+            var mouse = _mouseProvider();
+            if (mouse != null)
+            {
+                await mouse.MoveAndClickAsync(target);
+            }
+            else
+            {
+                await target.ClickAsync();
+            }
+
+            await Task.Delay(_random.Next(600, 1400));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed during menu misclick simulation on home page.");
+        }
+    }
+}

--- a/Services/YouTube/RecommendationChainService.cs
+++ b/Services/YouTube/RecommendationChainService.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class RecommendationChainService
+{
+    private readonly Func<Task<IPage>> _ensurePage;
+    private readonly Func<MouseHelper?> _mouseProvider;
+    private readonly Random _random;
+    private readonly ILogger? _logger;
+    private readonly VideoPlayerService _videoPlayer;
+    private readonly Func<IPage, string, Task> _waitForNavigationAsync;
+
+    public RecommendationChainService(
+        Func<Task<IPage>> ensurePage,
+        Func<MouseHelper?> mouseProvider,
+        Random random,
+        ILogger? logger,
+        VideoPlayerService videoPlayer,
+        Func<IPage, string, Task> waitForNavigationAsync)
+    {
+        _ensurePage = ensurePage;
+        _mouseProvider = mouseProvider;
+        _random = random;
+        _logger = logger;
+        _videoPlayer = videoPlayer;
+        _waitForNavigationAsync = waitForNavigationAsync;
+    }
+
+    public async Task MaybeChainRecommendedVideosAsync(YouTubeWarmupSettings warmup, VideoWatchResult parent)
+    {
+        if (parent.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short)
+        {
+            await ChainShortsAsync(warmup, parent);
+            return;
+        }
+
+        int maxChain = Math.Clamp(warmup.MaxRecommendationDepth, 0, 5);
+        if (maxChain <= 0)
+        {
+            return;
+        }
+
+        var page = await _ensurePage();
+        VideoWatchResult? current = parent;
+
+        for (int i = 0; i < maxChain; i++)
+        {
+            string previousUrl = page.Url;
+            bool navigated;
+            string method;
+            string contextDetail;
+            int? position = null;
+
+            bool useAutoplay = i == 0 && _random.NextDouble() < Math.Clamp(warmup.AutoplayFollowProbability, 0, 1);
+            if (useAutoplay)
+            {
+                navigated = await TriggerAutoplayAsync(page);
+                method = "Autoplay";
+                contextDetail = "AutoplayNext";
+            }
+            else
+            {
+                int? selection = await OpenRecommendedSidebarVideoAsync(page);
+                navigated = selection.HasValue;
+                method = "ManualSidebar";
+                if (!navigated)
+                {
+                    break;
+                }
+
+                position = selection!.Value + 1;
+                contextDetail = $"Sidebar#{position}";
+            }
+
+            if (!navigated)
+            {
+                break;
+            }
+
+            await _waitForNavigationAsync(page, previousUrl);
+            if (string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger?.LogDebug("Recommended navigation did not change URL. Ending chain early.");
+                break;
+            }
+
+            var result = await _videoPlayer.WatchCurrentEntryAsync(
+                warmup,
+                context: "RecommendationNext",
+                method: method,
+                contextDetail: contextDetail,
+                entryPoint: current?.EntryPoint ?? "Recommendation",
+                keyword: null,
+                position: position,
+                parent: current);
+            if (result == null)
+            {
+                break;
+            }
+
+            current = result;
+        }
+    }
+
+    private async Task ChainShortsAsync(YouTubeWarmupSettings warmup, VideoWatchResult parent)
+    {
+        var page = await _ensurePage();
+        VideoWatchResult? current = parent;
+
+        for (int i = 0; i < Math.Clamp(warmup.MaxRecommendationDepth, 0, 5); i++)
+        {
+            string previousUrl = page.Url;
+            bool advanced = await TryNavigateShortContinuationAsync(page);
+            if (!advanced)
+            {
+                break;
+            }
+
+            await _waitForNavigationAsync(page, previousUrl);
+
+            var result = await _videoPlayer.WatchCurrentEntryAsync(
+                warmup,
+                context: "RecommendationShort",
+                method: "ShortsNavigation",
+                contextDetail: $"ShortRecommendation#{i + 1}",
+                entryPoint: current?.EntryPoint ?? "Shorts",
+                keyword: null,
+                position: i + 1,
+                parent: current);
+
+            if (result == null)
+            {
+                break;
+            }
+
+            current = result;
+        }
+    }
+
+    private async Task<bool> TryNavigateShortContinuationAsync(IPage page)
+    {
+        try
+        {
+            string previousUrl = page.Url;
+            var mouse = _mouseProvider();
+            var downButton = page.Locator("#navigation-button-down button, #navigation-button-down tp-yt-paper-button, #navigation-button-down");
+            if (await downButton.CountAsync() > 0 && await downButton.First.IsVisibleAsync())
+            {
+                if (mouse != null)
+                {
+                    await mouse.MoveAndClickAsync(downButton.First);
+                }
+                else
+                {
+                    await downButton.First.ClickAsync();
+                }
+            }
+            else
+            {
+                await page.Keyboard.PressAsync("ArrowDown");
+            }
+
+            for (int attempt = 0; attempt < 20; attempt++)
+            {
+                await Task.Delay(400);
+                if (!string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to navigate to next short during recommendation chain.");
+        }
+
+        return false;
+    }
+
+    private async Task<bool> TriggerAutoplayAsync(IPage page)
+    {
+        try
+        {
+            await Task.Delay(_random.Next(1800, 3200));
+            if (_random.NextDouble() < 0.6)
+            {
+                await page.Keyboard.PressAsync("Shift+N");
+            }
+            else
+            {
+                var mouse = _mouseProvider();
+                var nextButton = page.Locator("a[aria-label*='Next'], button[aria-label*='Next']");
+                if (await nextButton.CountAsync() > 0)
+                {
+                    if (mouse != null)
+                    {
+                        await mouse.MoveAndClickAsync(nextButton.First);
+                    }
+                    else
+                    {
+                        await nextButton.First.ClickAsync();
+                    }
+                }
+                else
+                {
+                    await page.Keyboard.PressAsync("Shift+N");
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to trigger autoplay navigation.");
+            return false;
+        }
+    }
+
+    private async Task<int?> OpenRecommendedSidebarVideoAsync(IPage page)
+    {
+        try
+        {
+            var recTiles = page.Locator(
+                "#items > yt-lockup-view-model a#thumbnail, " +
+                "ytd-compact-video-renderer a#thumbnail, " +
+                "ytd-watch-next-secondary-results-renderer a#thumbnail");
+            int count = await recTiles.CountAsync();
+            if (count == 0)
+            {
+                return null;
+            }
+
+            int selectionCount = Math.Min(count, 6);
+            int index = _random.Next(0, selectionCount);
+            var target = recTiles.Nth(index);
+            await ScrollHelper.ScrollToElementAsync(page, target);
+            var mouse = _mouseProvider();
+            if (mouse != null)
+            {
+                await mouse.MoveAndClickAsync(target);
+            }
+            else
+            {
+                await target.ClickAsync();
+            }
+
+            return index;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to open recommended video from sidebar.");
+            return null;
+        }
+    }
+}

--- a/Services/YouTube/SearchInteractionService.cs
+++ b/Services/YouTube/SearchInteractionService.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class SearchInteractionService
+{
+    private readonly Func<Task<IPage>> _ensurePage;
+    private readonly Func<YouTubeWarmupSettings, Task> _ensureOnYouTube;
+    private readonly Func<string?, Task<string>> _pickKeywordAsync;
+    private readonly Action<string> _registerKeywordUsage;
+    private readonly Func<Task<ILocator>> _focusSearchBoxAsync;
+    private readonly Func<ILocator, Task> _clearInputAsync;
+    private readonly Func<IPage, string, Task> _waitForNavigationAsync;
+    private readonly VideoPlayerService _videoPlayer;
+    private readonly RecommendationChainService _recommendationChain;
+    private readonly Random _random;
+    private readonly Func<MouseHelper?> _mouseProvider;
+    private readonly Func<KeyboardHelper?> _keyboardProvider;
+    private readonly ILogger? _logger;
+    private readonly Func<YouTubeWarmupSettings, Task<bool>> _homeFallback;
+
+    public SearchInteractionService(
+        Func<Task<IPage>> ensurePage,
+        Func<YouTubeWarmupSettings, Task> ensureOnYouTube,
+        Func<string?, Task<string>> pickKeywordAsync,
+        Action<string> registerKeywordUsage,
+        Func<Task<ILocator>> focusSearchBoxAsync,
+        Func<ILocator, Task> clearInputAsync,
+        Func<IPage, string, Task> waitForNavigationAsync,
+        VideoPlayerService videoPlayer,
+        RecommendationChainService recommendationChain,
+        Random random,
+        Func<MouseHelper?> mouseProvider,
+        Func<KeyboardHelper?> keyboardProvider,
+        ILogger? logger,
+        Func<YouTubeWarmupSettings, Task<bool>> homeFallback)
+    {
+        _ensurePage = ensurePage;
+        _ensureOnYouTube = ensureOnYouTube;
+        _pickKeywordAsync = pickKeywordAsync;
+        _registerKeywordUsage = registerKeywordUsage;
+        _focusSearchBoxAsync = focusSearchBoxAsync;
+        _clearInputAsync = clearInputAsync;
+        _waitForNavigationAsync = waitForNavigationAsync;
+        _videoPlayer = videoPlayer;
+        _recommendationChain = recommendationChain;
+        _random = random;
+        _mouseProvider = mouseProvider;
+        _keyboardProvider = keyboardProvider;
+        _logger = logger;
+        _homeFallback = homeFallback;
+    }
+
+    public async Task<bool> ExecuteAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    {
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            bool success = await RunSingleSearchAsync(keywordDirectory, warmup, attempt);
+            if (success)
+            {
+                return true;
+            }
+
+            await Task.Delay(_random.Next(1200, 2200));
+        }
+
+        _logger?.LogInformation("All YouTube search retries failed; falling back to home recommendations.");
+        return await _homeFallback(warmup);
+    }
+
+    private async Task<bool> RunSingleSearchAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, int attempt)
+    {
+        try
+        {
+            var page = await _ensurePage();
+            await _ensureOnYouTube(warmup);
+
+            string keyword = await _pickKeywordAsync(keywordDirectory);
+            _registerKeywordUsage(keyword);
+            _logger?.LogInformation("YouTube search attempt {Attempt} using keyword '{Keyword}'.", attempt + 1, keyword);
+
+            var input = await _focusSearchBoxAsync();
+            await _clearInputAsync(input);
+            var keyboardHelper = _keyboardProvider();
+            if (keyboardHelper != null)
+            {
+                await keyboardHelper.TypeLikeHumanAsync(input, keyword);
+            }
+            else
+            {
+                await input.TypeAsync(keyword);
+            }
+
+            await Task.Delay(_random.Next(400, 1200));
+            await MaybeMisclickFilterAsync(page);
+
+            double decision = _random.NextDouble();
+            string previousUrl = page.Url;
+            if (decision < 0.4)
+            {
+                var searchButton = page.Locator("button#search-icon-legacy");
+                if (await searchButton.CountAsync() > 0 && await searchButton.IsVisibleAsync())
+                {
+                    var mouse = _mouseProvider();
+                    if (mouse != null)
+                    {
+                        await mouse.MoveAndClickAsync(searchButton);
+                    }
+                    else
+                    {
+                        await searchButton.ClickAsync();
+                    }
+                }
+                else
+                {
+                    await input.PressAsync("Enter");
+                }
+            }
+            else if (decision < 0.75)
+            {
+                await input.PressAsync("Enter");
+            }
+            else
+            {
+                var mouse = _mouseProvider();
+                if (mouse != null)
+                {
+                    await mouse.MoveAndClickAsync(input);
+                }
+                await input.PressAsync("Enter");
+            }
+
+            await _waitForNavigationAsync(page, previousUrl);
+
+            var videoTiles = page.Locator("ytd-video-renderer a#thumbnail, ytd-grid-video-renderer a#thumbnail");
+            int tileCount = await videoTiles.CountAsync();
+            if (tileCount == 0)
+            {
+                _logger?.LogWarning("YouTube search returned no video results.");
+                return false;
+            }
+
+            int index = _random.Next(0, tileCount);
+            var target = videoTiles.Nth(index);
+            var mouseHelper = _mouseProvider();
+            if (mouseHelper != null)
+            {
+                await mouseHelper.MoveAndClickAsync(target);
+            }
+            else
+            {
+                await target.ClickAsync();
+            }
+
+            string beforeClickUrl = page.Url;
+            await _waitForNavigationAsync(page, beforeClickUrl);
+
+            var result = await _videoPlayer.WatchCurrentEntryAsync(
+                warmup,
+                context: "Search",
+                method: "SearchResult",
+                contextDetail: $"SearchResult#{index + 1}",
+                entryPoint: "Search",
+                keyword: keyword,
+                position: index + 1,
+                parent: null);
+            if (result == null)
+            {
+                return false;
+            }
+
+            await _recommendationChain.MaybeChainRecommendedVideosAsync(warmup, result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "YouTube search attempt {Attempt} failed due to exception.", attempt + 1);
+            return false;
+        }
+    }
+
+    private async Task MaybeMisclickFilterAsync(IPage page)
+    {
+        if (_random.NextDouble() > 0.2)
+        {
+            return;
+        }
+
+        try
+        {
+            var filtersButton = page.Locator("ytd-toggle-button-renderer a[aria-label*='Filters'], ytd-search-sub-menu-renderer button");
+            if (await filtersButton.CountAsync() == 0)
+            {
+                return;
+            }
+
+            var mouse = _mouseProvider();
+            if (mouse != null)
+            {
+                await mouse.MoveAndClickAsync(filtersButton.First);
+            }
+            else
+            {
+                await filtersButton.First.ClickAsync();
+            }
+
+            await Task.Delay(_random.Next(600, 1200));
+            if (_random.NextDouble() < 0.5)
+            {
+                await page.Keyboard.PressAsync("Escape");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed during misclick simulation before search.");
+        }
+    }
+}

--- a/Services/YouTube/ShortsInteractionService.cs
+++ b/Services/YouTube/ShortsInteractionService.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class ShortsInteractionService
+{
+    private readonly Func<Task<IPage>> _ensurePage;
+    private readonly Func<YouTubeWarmupSettings, Task> _ensureOnYouTube;
+    private readonly Func<string> _getBaseDomain;
+    private readonly Func<IPage, string, Task> _waitForNavigationAsync;
+    private readonly VideoPlayerService _videoPlayer;
+    private readonly Random _random;
+    private readonly Func<MouseHelper?> _mouseProvider;
+    private readonly ILogger? _logger;
+
+    public ShortsInteractionService(
+        Func<Task<IPage>> ensurePage,
+        Func<YouTubeWarmupSettings, Task> ensureOnYouTube,
+        Func<string> getBaseDomain,
+        Func<IPage, string, Task> waitForNavigationAsync,
+        VideoPlayerService videoPlayer,
+        Random random,
+        Func<MouseHelper?> mouseProvider,
+        ILogger? logger)
+    {
+        _ensurePage = ensurePage;
+        _ensureOnYouTube = ensureOnYouTube;
+        _getBaseDomain = getBaseDomain;
+        _waitForNavigationAsync = waitForNavigationAsync;
+        _videoPlayer = videoPlayer;
+        _random = random;
+        _mouseProvider = mouseProvider;
+        _logger = logger;
+    }
+
+    public async Task<bool> ExecuteAsync(YouTubeWarmupSettings warmup, bool preferGuideMenu)
+    {
+        var page = await _ensurePage();
+        await _ensureOnYouTube(warmup);
+
+        bool guideOpened = false;
+        if (preferGuideMenu)
+        {
+            guideOpened = await TryEnsureGuideMenuVisibleAsync(page);
+        }
+
+        var shortsLink = await TryFindShortsLinkAsync(page);
+        if (shortsLink == null || !await shortsLink.IsVisibleAsync())
+        {
+            if (!guideOpened)
+            {
+                guideOpened = await TryEnsureGuideMenuVisibleAsync(page);
+            }
+
+            shortsLink = await TryFindShortsLinkAsync(page);
+        }
+
+        if (shortsLink == null || !await shortsLink.IsVisibleAsync())
+        {
+            if (_random.NextDouble() < 0.15)
+            {
+                await page.GotoAsync($"{_getBaseDomain().TrimEnd('/')}/shorts", new PageGotoOptions
+                {
+                    Timeout = 45000,
+                    WaitUntil = WaitUntilState.DOMContentLoaded
+                });
+                await Task.Delay(_random.Next(800, 1500));
+                return await WatchShortsSequenceAsync(warmup);
+            }
+
+            return false;
+        }
+
+        var mouse = _mouseProvider();
+        if (mouse != null)
+        {
+            await mouse.MoveAndClickAsync(shortsLink);
+        }
+        else
+        {
+            await shortsLink.ClickAsync();
+        }
+
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await Task.Delay(_random.Next(1000, 2000));
+
+        return await WatchShortsSequenceAsync(warmup);
+    }
+
+    private async Task<bool> WatchShortsSequenceAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await _ensurePage();
+        var shortsTiles = page.Locator("ytd-reel-video-renderer a#thumbnail, ytd-reel-item-renderer a#thumbnail");
+        int count = await shortsTiles.CountAsync();
+        if (count == 0)
+        {
+            _logger?.LogWarning("No shorts available after navigating to Shorts page.");
+            return false;
+        }
+
+        int index = _random.Next(0, count);
+        var target = shortsTiles.Nth(index);
+        string beforeClickUrl = page.Url;
+        var mouse = _mouseProvider();
+        if (mouse != null)
+        {
+            await mouse.MoveAndClickAsync(target);
+        }
+        else
+        {
+            await target.ClickAsync();
+        }
+
+        await _waitForNavigationAsync(page, beforeClickUrl);
+
+        int minSequence = Math.Max(1, warmup.MinShortSequenceLength);
+        int maxSequence = Math.Max(minSequence, warmup.MaxShortSequenceLength);
+        int sequenceCount = _random.Next(minSequence, maxSequence + 1);
+
+        VideoWatchResult? previous = null;
+        for (int i = 0; i < sequenceCount; i++)
+        {
+            string context = i == 0 ? "Shorts" : "ShortsContinuation";
+            string method = i == 0 ? "InitialShort" : "NextShort";
+            string detail = $"Shorts#{i + 1}";
+            string entryPoint = previous?.EntryPoint ?? "Shorts";
+
+            var result = await _videoPlayer.WatchShortAsync(
+                warmup,
+                context,
+                method,
+                detail,
+                entryPoint,
+                position: i + 1,
+                parent: previous);
+            if (result == null)
+            {
+                break;
+            }
+
+            previous = result;
+
+            if (i < sequenceCount - 1)
+            {
+                bool advanced = await AdvanceToNextShortAsync();
+                if (!advanced)
+                {
+                    break;
+                }
+            }
+        }
+
+        return previous != null;
+    }
+
+    private async Task<bool> AdvanceToNextShortAsync()
+    {
+        var page = await _ensurePage();
+        try
+        {
+            string previousUrl = page.Url;
+            if (_random.NextDouble() < 0.55)
+            {
+                await page.Keyboard.PressAsync("ArrowDown");
+                await _waitForNavigationAsync(page, previousUrl);
+                return true;
+            }
+
+            var mouse = _mouseProvider();
+            var nextButton = page.Locator("button[aria-label*='Next'], button[aria-label*='Tiếp'], button[aria-label*='Sau']");
+            if (await nextButton.CountAsync() > 0 && await nextButton.First.IsEnabledAsync())
+            {
+                if (mouse != null)
+                {
+                    await mouse.MoveAndClickAsync(nextButton.First);
+                }
+                else
+                {
+                    await nextButton.First.ClickAsync();
+                }
+
+                await _waitForNavigationAsync(page, previousUrl);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to advance to next short.");
+        }
+
+        return false;
+    }
+
+    private async Task<bool> TryEnsureGuideMenuVisibleAsync(IPage page)
+    {
+        try
+        {
+            var guideButton = page.Locator("button#guide-button, #guide-button");
+            if (await guideButton.CountAsync() == 0)
+            {
+                return false;
+            }
+
+            var target = guideButton.First;
+            if (await target.GetAttributeAsync("pressed") == "true")
+            {
+                return true;
+            }
+
+            var mouse = _mouseProvider();
+            if (mouse != null)
+            {
+                await mouse.MoveAndClickAsync(target);
+            }
+            else
+            {
+                await target.ClickAsync();
+            }
+
+            await Task.Delay(_random.Next(600, 1200));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to toggle guide menu for shorts.");
+            return false;
+        }
+    }
+
+    private async Task<ILocator?> TryFindShortsLinkAsync(IPage page)
+    {
+        try
+        {
+            var locator = page.Locator("ytd-mini-guide-entry-renderer:nth-child(2) a, a[title='Shorts'], a[title='SHORTS']");
+            if (await locator.CountAsync() == 0)
+            {
+                return null;
+            }
+
+            return locator.First;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to locate shorts link.");
+            return null;
+        }
+    }
+}

--- a/Services/YouTube/VideoPlayerService.cs
+++ b/Services/YouTube/VideoPlayerService.cs
@@ -1,0 +1,659 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class VideoPlayerService
+{
+    private readonly Func<Task<IPage>> _ensurePage;
+    private readonly Func<MouseHelper?> _mouseProvider;
+    private readonly Func<KeyboardHelper?> _keyboardProvider;
+    private readonly Random _random;
+    private readonly ILogger? _logger;
+    private readonly Func<YouTubeWarmupService.IdentityPlaybackPreferences?> _playbackPreferencesAccessor;
+    private readonly Action<VideoWatchResult> _recordWatch;
+    private readonly Func<Task> _pauseBetweenActions;
+
+    public VideoPlayerService(
+        Func<Task<IPage>> ensurePage,
+        Func<MouseHelper?> mouseProvider,
+        Func<KeyboardHelper?> keyboardProvider,
+        Random random,
+        ILogger? logger,
+        Func<YouTubeWarmupService.IdentityPlaybackPreferences?> playbackPreferencesAccessor,
+        Action<VideoWatchResult> recordWatch,
+        Func<Task> pauseBetweenActions)
+    {
+        _ensurePage = ensurePage;
+        _mouseProvider = mouseProvider;
+        _keyboardProvider = keyboardProvider;
+        _random = random;
+        _logger = logger;
+        _playbackPreferencesAccessor = playbackPreferencesAccessor;
+        _recordWatch = recordWatch;
+        _pauseBetweenActions = pauseBetweenActions;
+    }
+
+    public async Task<VideoWatchResult?> WatchCurrentEntryAsync(
+        YouTubeWarmupSettings warmup,
+        string context,
+        string method,
+        string contextDetail,
+        string entryPoint,
+        string? keyword,
+        int? position,
+        VideoWatchResult? parent)
+    {
+        var page = await _ensurePage();
+        var kind = YouTubeUrlHelper.GetVideoKind(page.Url);
+
+        return kind == YouTubeUrlHelper.YouTubeVideoKind.Short
+            ? await WatchShortAsync(
+                warmup,
+                context,
+                method,
+                contextDetail,
+                entryPoint,
+                position,
+                parent)
+            : await WatchVideoAsync(
+                warmup,
+                context,
+                method,
+                contextDetail,
+                entryPoint,
+                keyword,
+                position,
+                parent,
+                kind);
+    }
+
+    public async Task<VideoWatchResult?> WatchVideoAsync(
+        YouTubeWarmupSettings warmup,
+        string context,
+        string method,
+        string contextDetail,
+        string entryPoint,
+        string? keyword,
+        int? position,
+        VideoWatchResult? parent,
+        YouTubeUrlHelper.YouTubeVideoKind detectedKind)
+    {
+        var page = await _ensurePage();
+        try
+        {
+            await WaitForStandardPlayerAsync(page);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Video element did not appear for context {Context}.", context);
+        }
+
+        await FocusPlayerAsync(page, detectedKind);
+        await MaybeSkipAdsAsync(page);
+
+        int? volumePercent = await MaybeAdjustVolumeAsync(page);
+        int planned = PlanWatchDuration(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
+        int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
+        var start = DateTimeOffset.Now;
+        var stopwatch = Stopwatch.StartNew();
+
+        await MaybeJitterMouseAsync(page);
+        await MaybeInteractWithPlayerUiAsync(page);
+
+        await page.WaitForTimeoutAsync(actualTarget);
+
+        if (_random.NextDouble() < 0.3)
+        {
+            await page.Keyboard.PressAsync("Space");
+            await Task.Delay(_random.Next(800, 1500));
+            await page.Keyboard.PressAsync("Space");
+        }
+
+        if (_random.NextDouble() < 0.4)
+        {
+            await ScrollHelper.ScrollRandomAsync(page, _random.Next(1, 4));
+        }
+
+        stopwatch.Stop();
+
+        var result = new VideoWatchResult
+        {
+            Context = context,
+            ContextDetail = contextDetail,
+            EntryPoint = string.IsNullOrWhiteSpace(entryPoint) ? context : entryPoint,
+            Method = method,
+            ResultPosition = position,
+            Keyword = keyword,
+            Url = page.Url,
+            Title = await TryGetInnerTextAsync(page.Locator("h1 yt-formatted-string")),
+            ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-name a")),
+            PlannedWatchDurationMs = planned,
+            ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
+            StartedAt = start,
+            IsShort = false,
+            ParentVideoUrl = parent?.Url,
+            ParentVideoTitle = parent?.Title,
+            ParentContext = parent?.ContextDetail ?? parent?.Context,
+            VolumePercent = volumePercent
+        };
+
+        result.VideoType = YouTubeUrlHelper.GetVideoKind(result.Url);
+        result.IsShort = result.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short;
+
+        _recordWatch(result);
+        await _pauseBetweenActions();
+        return result;
+    }
+
+    public async Task<VideoWatchResult?> WatchShortAsync(
+        YouTubeWarmupSettings warmup,
+        string context,
+        string method,
+        string contextDetail,
+        string entryPoint,
+        int? position,
+        VideoWatchResult? parent)
+    {
+        var page = await _ensurePage();
+        await WaitForShortPlayerAsync(page);
+        await FocusPlayerAsync(page, YouTubeUrlHelper.YouTubeVideoKind.Short);
+        await MaybeSkipAdsAsync(page);
+
+        int? volumePercent = await MaybeAdjustVolumeAsync(page);
+        int planned = PlanWatchDuration(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
+        int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
+        var start = DateTimeOffset.Now;
+        var stopwatch = Stopwatch.StartNew();
+
+        await MaybeJitterMouseAsync(page);
+
+        await page.WaitForTimeoutAsync(actualTarget);
+
+        if (_random.NextDouble() < 0.25)
+        {
+            await page.Keyboard.PressAsync("ArrowUp");
+            await page.Keyboard.PressAsync("ArrowDown");
+        }
+
+        stopwatch.Stop();
+
+        var result = new VideoWatchResult
+        {
+            Context = context,
+            ContextDetail = contextDetail,
+            EntryPoint = string.IsNullOrWhiteSpace(entryPoint) ? context : entryPoint,
+            Method = method,
+            ResultPosition = position,
+            Keyword = null,
+            Url = page.Url,
+            Title = await TryGetInnerTextAsync(page.Locator("h1 yt-formatted-string")),
+            ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-name a")),
+            PlannedWatchDurationMs = planned,
+            ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
+            StartedAt = start,
+            IsShort = true,
+            ParentVideoUrl = parent?.Url,
+            ParentVideoTitle = parent?.Title,
+            ParentContext = parent?.ContextDetail ?? parent?.Context,
+            VolumePercent = volumePercent,
+            VideoType = YouTubeUrlHelper.YouTubeVideoKind.Short
+        };
+
+        _recordWatch(result);
+        await _pauseBetweenActions();
+        return result;
+    }
+
+    private async Task MaybeSkipAdsAsync(IPage page)
+    {
+        var adOverlay = page.Locator(".ytp-ad-player-overlay, .ytp-ad-overlay-slot, .ad-showing");
+        try
+        {
+            if (await adOverlay.CountAsync() == 0)
+            {
+                return;
+            }
+
+            int dwellMs = await DetermineAdDwellAsync(page);
+            if (dwellMs > 0)
+            {
+                await page.WaitForTimeoutAsync(dwellMs);
+            }
+
+            string[] skipSelectors =
+            {
+                "button.ytp-ad-skip-button", "button.ytp-ad-skip-button-modern", "div.ytp-ad-skip-button-slot button",
+                "yt-button-renderer#skip-button button", "button[aria-label*='Skip']"
+            };
+
+            for (int attempt = 0; attempt < 6; attempt++)
+            {
+                bool stillShowing = await page.EvaluateAsync<bool>(
+                    "() => document.querySelector('.ad-showing, .ytp-ad-player-overlay, .ytp-ad-overlay-slot') !== null");
+                if (!stillShowing)
+                {
+                    return;
+                }
+
+                foreach (string selector in skipSelectors)
+                {
+                    var skipButton = page.Locator(selector);
+                    if (await skipButton.CountAsync() == 0)
+                    {
+                        continue;
+                    }
+
+                    var target = skipButton.First;
+                    if (!await target.IsVisibleAsync())
+                    {
+                        continue;
+                    }
+
+                    _logger?.LogDebug("Attempting to skip YouTube ad using selector {Selector}.", selector);
+                    var mouse = _mouseProvider();
+                    if (mouse != null)
+                    {
+                        await mouse.MoveAndClickAsync(target);
+                    }
+                    else
+                    {
+                        await target.ClickAsync(new LocatorClickOptions { Timeout = 2000 });
+                    }
+
+                    await Task.Delay(_random.Next(600, 1200));
+                    return;
+                }
+
+                await Task.Delay(_random.Next(500, 900));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed while attempting to skip YouTube ads.");
+        }
+    }
+
+    private async Task<int> DetermineAdDwellAsync(IPage page)
+    {
+        try
+        {
+            string? durationText = await page.EvaluateAsync<string?>(
+                "() => { const el = document.querySelector('.ytp-time-duration, .ytp-ad-duration-remaining'); return el ? el.textContent : null; }");
+            int? durationMs = ParseDurationToMilliseconds(durationText);
+            if (!durationMs.HasValue)
+            {
+                return _random.Next(4000, 6500);
+            }
+
+            if (durationMs.Value <= 15000)
+            {
+                return _random.Next(4200, 6000);
+            }
+
+            if (durationMs.Value <= 30000)
+            {
+                return _random.Next(5000, 9000);
+            }
+
+            return _random.Next(6500, 12000);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to determine ad dwell time.");
+            return _random.Next(4000, 6500);
+        }
+    }
+
+    private static int? ParseDurationToMilliseconds(string? durationText)
+    {
+        if (string.IsNullOrWhiteSpace(durationText))
+        {
+            return null;
+        }
+
+        durationText = durationText.Trim();
+        var parts = durationText.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return null;
+        }
+
+        int seconds = 0;
+        int multiplier = 1;
+
+        for (int i = parts.Length - 1; i >= 0; i--)
+        {
+            if (!int.TryParse(parts[i], out int value))
+            {
+                return null;
+            }
+
+            seconds += value * multiplier;
+            multiplier *= 60;
+        }
+
+        return seconds * 1000;
+    }
+
+    private async Task<int?> MaybeAdjustVolumeAsync(IPage page)
+    {
+        var playback = _playbackPreferencesAccessor();
+        if (playback == null)
+        {
+            return null;
+        }
+
+        playback.MinVolumePercent = Math.Clamp(playback.MinVolumePercent, 0, 100);
+        playback.MaxVolumePercent = Math.Clamp(playback.MaxVolumePercent, 0, 100);
+        if (playback.MinVolumePercent > playback.MaxVolumePercent)
+        {
+            (playback.MinVolumePercent, playback.MaxVolumePercent) = (playback.MaxVolumePercent, playback.MinVolumePercent);
+        }
+
+        playback.VolumeAdjustmentChance = Math.Clamp(playback.VolumeAdjustmentChance, 0, 1);
+        if (playback.VolumeAdjustmentChance <= 0)
+        {
+            playback.VolumeAdjustmentChance = 0.6;
+        }
+
+        if (_random.NextDouble() > playback.VolumeAdjustmentChance)
+        {
+            return playback.LastVolumePercent;
+        }
+
+        double? currentVolume = null;
+        try
+        {
+            currentVolume = await page.EvaluateAsync<double?>("() => { const video = document.querySelector('video'); return video ? video.volume : null; }");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to read current YouTube volume.");
+        }
+
+        int min = playback.MinVolumePercent;
+        int max = playback.MaxVolumePercent;
+        int targetPercent = min == max ? min : _random.Next(min, max + 1);
+        double targetVolume = Math.Clamp(targetPercent / 100.0, 0, 1);
+
+        if (currentVolume.HasValue && Math.Abs(currentVolume.Value - targetVolume) < 0.03 && _random.NextDouble() < 0.4)
+        {
+            int currentPercent = Math.Clamp((int)Math.Round(currentVolume.Value * 100), 0, 100);
+            playback.LastVolumePercent = currentPercent;
+            return currentPercent;
+        }
+
+        var videoLocator = page.Locator("video.html5-main-video, ytd-player video");
+        try
+        {
+            if (await videoLocator.CountAsync() > 0)
+            {
+                var mouse = _mouseProvider();
+                if (mouse != null)
+                {
+                    await mouse.MoveAndClickAsync(videoLocator.First);
+                }
+                else
+                {
+                    await videoLocator.First.ClickAsync();
+                }
+
+                await Task.Delay(_random.Next(120, 260));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to focus video element before adjusting volume.");
+        }
+
+        bool usedKeyboard = _random.NextDouble() < 0.65;
+        if (usedKeyboard)
+        {
+            double startingVolume = currentVolume ?? (playback.LastVolumePercent.HasValue ? playback.LastVolumePercent.Value / 100.0 : 0.5);
+            double step = 0.05;
+            int steps = (int)Math.Round((targetVolume - startingVolume) / step);
+            string key = steps >= 0 ? "ArrowUp" : "ArrowDown";
+
+            for (int i = 0; i < Math.Abs(steps); i++)
+            {
+                await page.Keyboard.PressAsync(key);
+                await Task.Delay(_random.Next(70, 150));
+            }
+        }
+        else
+        {
+            try
+            {
+                await page.EvaluateAsync("(vol) => { const video = document.querySelector('video'); if (video) { video.volume = Math.min(1, Math.max(0, vol)); } }", targetVolume);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "Failed to set YouTube volume via script.");
+            }
+        }
+
+        double? finalVolume = null;
+        try
+        {
+            finalVolume = await page.EvaluateAsync<double?>("() => { const video = document.querySelector('video'); return video ? video.volume : null; }");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to read final YouTube volume.");
+        }
+
+        int? finalPercent = finalVolume.HasValue
+            ? (int?)Math.Clamp((int)Math.Round(finalVolume.Value * 100), 0, 100)
+            : targetPercent;
+
+        playback.LastVolumePercent = finalPercent;
+        return finalPercent;
+    }
+
+    private async Task WaitForStandardPlayerAsync(IPage page)
+    {
+        await page.WaitForSelectorAsync("video.html5-main-video, ytd-player video", new PageWaitForSelectorOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = 15000
+        });
+    }
+
+    private async Task WaitForShortPlayerAsync(IPage page)
+    {
+        await page.WaitForSelectorAsync("ytd-reel-video-renderer, #shorts-player", new PageWaitForSelectorOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = 15000
+        });
+    }
+
+    private async Task FocusPlayerAsync(IPage page, YouTubeUrlHelper.YouTubeVideoKind kind)
+    {
+        try
+        {
+            if (kind == YouTubeUrlHelper.YouTubeVideoKind.Short)
+            {
+                await page.Keyboard.PressAsync("k");
+                await Task.Delay(_random.Next(400, 900));
+                return;
+            }
+
+            var player = page.Locator("video.html5-main-video, ytd-player video");
+            if (await player.CountAsync() > 0)
+            {
+                var mouse = _mouseProvider();
+                if (mouse != null)
+                {
+                    await mouse.MoveAndClickAsync(player.First);
+                }
+                else
+                {
+                    await player.First.ClickAsync();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to focus player for kind {Kind}.", kind);
+        }
+    }
+
+    private async Task MaybeJitterMouseAsync(IPage page)
+    {
+        if (_random.NextDouble() > 0.45)
+        {
+            return;
+        }
+
+        try
+        {
+            var mouse = _mouseProvider();
+            if (mouse == null)
+            {
+                return;
+            }
+
+            var viewport = await page.EvaluateAsync<int[]>("() => [window.innerWidth || 1280, window.innerHeight || 720]");
+            int width = viewport.Length > 0 ? viewport[0] : 1280;
+            int height = viewport.Length > 1 ? viewport[1] : 720;
+            int centerX = width / 2;
+            int seekBarY = height - _random.Next(160, 220);
+
+            await mouse.MoveAsync(centerX + _random.Next(-40, 40), seekBarY);
+            await Task.Delay(_random.Next(300, 700));
+            await mouse.MoveAsync(centerX + _random.Next(-20, 20), seekBarY - _random.Next(20, 50));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to perform mouse jitter on player.");
+        }
+    }
+
+    private async Task MaybeInteractWithPlayerUiAsync(IPage page)
+    {
+        if (_random.NextDouble() > 0.35)
+        {
+            return;
+        }
+
+        try
+        {
+            double roll = _random.NextDouble();
+            var mouse = _mouseProvider();
+
+            if (roll < 0.33)
+            {
+                var transcriptButton = page.Locator("button[aria-label*='Transcript'], button[aria-label*='Bản phiên âm']");
+                if (await transcriptButton.CountAsync() > 0 && await transcriptButton.First.IsVisibleAsync())
+                {
+                    if (mouse != null)
+                    {
+                        await mouse.MoveAndClickAsync(transcriptButton.First);
+                    }
+                    else
+                    {
+                        await transcriptButton.First.ClickAsync();
+                    }
+
+                    await Task.Delay(_random.Next(1500, 2800));
+                }
+            }
+            else if (roll < 0.66)
+            {
+                var likeButton = page.Locator("ytd-toggle-button-renderer#like-button button");
+                if (await likeButton.CountAsync() > 0)
+                {
+                    if (mouse != null)
+                    {
+                        await mouse.MoveAsync(_random.Next(200, 320), _random.Next(180, 260));
+                        await Task.Delay(_random.Next(200, 450));
+                        await mouse.MoveAndClickAsync(likeButton.First);
+                    }
+                    else
+                    {
+                        await likeButton.First.ClickAsync();
+                    }
+
+                    await Task.Delay(_random.Next(1200, 2000));
+                }
+            }
+            else
+            {
+                var avatar = page.Locator("#owner #avatar, #channel-name a");
+                if (await avatar.CountAsync() > 0)
+                {
+                    if (mouse != null)
+                    {
+                        await mouse.MoveAndHoverAsync(avatar.First);
+                    }
+                    else
+                    {
+                        await avatar.First.HoverAsync();
+                    }
+
+                    await Task.Delay(_random.Next(1000, 2000));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to trigger player UI interaction.");
+        }
+    }
+
+    private async Task<string?> TryGetInnerTextAsync(ILocator locator)
+    {
+        try
+        {
+            if (await locator.CountAsync() == 0)
+            {
+                return null;
+            }
+
+            return (await locator.First.InnerTextAsync())?.Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private int PlanWatchDuration(int min, int max)
+    {
+        if (min >= max)
+        {
+            return min;
+        }
+
+        double roll = _random.NextDouble();
+        int range = max - min;
+        int shortUpper = min + (int)(range * 0.2);
+        int mediumUpper = min + (int)(range * 0.7);
+
+        if (roll < 0.15)
+        {
+            return _random.Next(min, shortUpper + 1);
+        }
+
+        if (roll < 0.85)
+        {
+            return _random.Next(shortUpper, mediumUpper + 1);
+        }
+
+        return _random.Next(mediumUpper, max + 1);
+    }
+
+    private int ApplyWatchDurationJitter(int planned, int min, int max)
+    {
+        int jitter = (int)(planned * _random.NextDouble() * 0.2);
+        int adjusted = planned + (_random.NextDouble() < 0.5 ? -jitter : jitter);
+        return Math.Clamp(adjusted, min, max);
+    }
+}

--- a/Services/YouTube/VideoWatchResult.cs
+++ b/Services/YouTube/VideoWatchResult.cs
@@ -1,0 +1,40 @@
+using System;
+using GPM_driver.Helpers;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class VideoWatchResult
+{
+    public string Context { get; set; } = string.Empty;
+    public string ContextDetail { get; set; } = string.Empty;
+    public string EntryPoint { get; set; } = string.Empty;
+    public string Method { get; set; } = string.Empty;
+    public int? ResultPosition { get; set; }
+        = null;
+    public string? Keyword { get; set; }
+        = null;
+    public string? Url { get; set; }
+        = string.Empty;
+    public string? Title { get; set; }
+        = string.Empty;
+    public string? ChannelName { get; set; }
+        = string.Empty;
+    public int PlannedWatchDurationMs { get; set; }
+        = 0;
+    public int ActualWatchDurationMs { get; set; }
+        = 0;
+    public DateTimeOffset StartedAt { get; set; }
+        = DateTimeOffset.UtcNow;
+    public bool IsShort { get; set; }
+        = false;
+    public string? ParentVideoUrl { get; set; }
+        = null;
+    public string? ParentVideoTitle { get; set; }
+        = null;
+    public string? ParentContext { get; set; }
+        = null;
+    public YouTubeUrlHelper.YouTubeVideoKind VideoType { get; set; }
+        = YouTubeUrlHelper.YouTubeVideoKind.Unknown;
+    public int? VolumePercent { get; set; }
+        = null;
+}

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
+using GPM_driver.Services.YouTube;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 
@@ -36,6 +36,13 @@ internal class YouTubeWarmupService
     private DateTimeOffset _sessionStart;
     private long _sessionTotalWatchTimeMs;
     private int _sessionBounceCount;
+    private int _sessionFailureCount;
+
+    private VideoPlayerService? _videoPlayer;
+    private RecommendationChainService? _recommendationService;
+    private SearchInteractionService? _searchService;
+    private ShortsInteractionService? _shortsService;
+    private HomeInteractionService? _homeService;
 
     private static readonly string[] FallbackKeywords =
     {
@@ -53,7 +60,7 @@ internal class YouTubeWarmupService
         "try searching to get started"
     };
 
-    private sealed class YouTubeIdentityDocument
+    internal sealed class YouTubeIdentityDocument
     {
         public IdentityProfileInfo Profile { get; set; } = new();
         public KeywordSection Keywords { get; set; } = new();
@@ -62,7 +69,7 @@ internal class YouTubeWarmupService
         public List<string> SourceFiles { get; set; } = new();
     }
 
-    private sealed class IdentityProfileInfo
+    internal sealed class IdentityProfileInfo
     {
         public string ProfileId { get; set; } = string.Empty;
         public string Persona { get; set; } = "Generalist";
@@ -75,14 +82,14 @@ internal class YouTubeWarmupService
         public string[] Behaviors { get; set; } = Array.Empty<string>();
     }
 
-    private sealed class KeywordSection
+    internal sealed class KeywordSection
     {
         public List<string> SeedList { get; set; } = new();
         public List<KeywordUsageRecord> UsedHistory { get; set; } = new();
         public List<KeywordVideoRecord> KeywordHistory { get; set; } = new();
     }
 
-    private sealed class KeywordUsageRecord
+    internal sealed class KeywordUsageRecord
     {
         public string Keyword { get; set; } = string.Empty;
         public int TimesUsed { get; set; }
@@ -91,7 +98,7 @@ internal class YouTubeWarmupService
             = null;
     }
 
-    private sealed class KeywordVideoRecord
+    internal sealed class KeywordVideoRecord
     {
         public string Keyword { get; set; } = string.Empty;
         public string VideoUrl { get; set; } = string.Empty;
@@ -103,7 +110,7 @@ internal class YouTubeWarmupService
             = null;
     }
 
-    private sealed class IdentityPlaybackPreferences
+    internal sealed class IdentityPlaybackPreferences
     {
         public int MinVolumePercent { get; set; }
             = 20;
@@ -115,7 +122,7 @@ internal class YouTubeWarmupService
             = 0.6;
     }
 
-    private sealed class IdentityStats
+    internal sealed class IdentityStats
     {
         public int TotalSessions { get; set; }
             = 0;
@@ -133,6 +140,10 @@ internal class YouTubeWarmupService
             = 0;
         public int DeepSessions { get; set; }
             = 0;
+        public int FailedInteractions { get; set; }
+            = 0;
+        public double ErrorRate { get; set; }
+            = 0;
         public DateTimeOffset? LastSessionTimestamp { get; set; }
             = null;
         public DateTimeOffset? LastWatchedAt { get; set; }
@@ -141,7 +152,7 @@ internal class YouTubeWarmupService
         public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
     }
 
-    private sealed class SourceBreakdown
+    internal sealed class SourceBreakdown
     {
         public int SearchCount { get; set; }
             = 0;
@@ -155,42 +166,6 @@ internal class YouTubeWarmupService
             = 0;
         public double ShortsPercent { get; set; }
             = 0;
-    }
-
-    private sealed class VideoWatchResult
-    {
-        public string Context { get; set; } = string.Empty;
-        public string ContextDetail { get; set; } = string.Empty;
-        public string EntryPoint { get; set; } = string.Empty;
-        public string Method { get; set; } = string.Empty;
-        public int? ResultPosition { get; set; }
-            = null;
-        public string? Keyword { get; set; }
-            = null;
-        public string? Url { get; set; }
-            = string.Empty;
-        public string? Title { get; set; }
-            = string.Empty;
-        public string? ChannelName { get; set; }
-            = string.Empty;
-        public int PlannedWatchDurationMs { get; set; }
-            = 0;
-        public int ActualWatchDurationMs { get; set; }
-            = 0;
-        public DateTimeOffset StartedAt { get; set; }
-            = DateTimeOffset.UtcNow;
-        public bool IsShort { get; set; }
-            = false;
-        public string? ParentVideoUrl { get; set; }
-            = null;
-        public string? ParentVideoTitle { get; set; }
-            = null;
-        public string? ParentContext { get; set; }
-            = null;
-        public YouTubeUrlHelper.YouTubeVideoKind VideoType { get; set; }
-            = YouTubeUrlHelper.YouTubeVideoKind.Unknown;
-        public int? VolumePercent { get; set; }
-            = null;
     }
 
     private sealed class SessionInteraction
@@ -249,6 +224,8 @@ internal class YouTubeWarmupService
         public bool DeepChain { get; set; }
             = false;
         public SessionSourceBreakdown Sources { get; set; } = new();
+        public int FailedInteractions { get; set; }
+            = 0;
     }
 
     private sealed class SessionSourceBreakdown
@@ -306,20 +283,32 @@ internal class YouTubeWarmupService
         try
         {
             int completed = 0;
+            int attempts = 0;
             while (true)
             {
                 try
                 {
                     await EnsureOnYouTubeAsync(warmup);
-                    await PerformInteractionAsync(keywordDirectory, warmup);
+                    attempts++;
+                    bool success = await PerformInteractionAsync(keywordDirectory, warmup);
+                    if (success)
+                    {
+                        completed++;
+                    }
                 }
                 catch (Exception ex)
                 {
                     _logger?.LogWarning(ex, "YouTube interaction failed.");
+                    RegisterInteractionFailure();
                 }
 
                 _isFirstRun = false;
-                completed++;
+
+                if (attempts >= 2 && _sessionFailureCount > attempts / 2)
+                {
+                    _logger?.LogWarning("Ending YouTube warmup early due to elevated failure rate (failures={Failures} attempts={Attempts}).", _sessionFailureCount, attempts);
+                    break;
+                }
 
                 if (completed >= warmup.MaxInteractions)
                 {
@@ -351,34 +340,42 @@ internal class YouTubeWarmupService
         }
     }
 
-    private async Task PerformInteractionAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    private async Task<bool> PerformInteractionAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
     {
         await EnsureOnYouTubeAsync(warmup);
         var page = await EnsurePageAsync();
+        EnsureInteractionServices();
+
         bool freshLanding = await IsFreshLandingExperienceAsync(page);
+        bool success;
+
         if (freshLanding)
         {
             _logger?.LogInformation("Detected fresh YouTube landing page; prioritizing search and Shorts menu interactions.");
 
             if (_random.NextDouble() < 0.7)
             {
-                await SearchAndWatchAsync(keywordDirectory, warmup);
+                success = await _searchService!.ExecuteAsync(keywordDirectory, warmup);
             }
             else
             {
-                bool opened = await OpenShortsAsync(warmup, preferGuideMenu: true);
-                if (!opened)
+                success = await _shortsService!.ExecuteAsync(warmup, preferGuideMenu: true);
+                if (!success)
                 {
-                    await SearchAndWatchAsync(keywordDirectory, warmup);
+                    success = await _searchService!.ExecuteAsync(keywordDirectory, warmup);
                 }
             }
 
-            return;
+            if (!success)
+            {
+                RegisterInteractionFailure();
+            }
+
+            return success;
         }
 
         double normalizedSearchWeight = Math.Clamp(warmup.SearchWeight, 0, 1);
         double normalizedShortsWeight = Math.Clamp(warmup.ShortsWeight, 0, 1 - normalizedSearchWeight);
-        double homeWeight = 1 - normalizedSearchWeight - normalizedShortsWeight;
 
         double roll = _random.NextDouble();
         if (_isFirstRun)
@@ -389,24 +386,30 @@ internal class YouTubeWarmupService
         if (roll < normalizedSearchWeight)
         {
             _logger?.LogInformation("YouTube warmup selected search interaction.");
-            await SearchAndWatchAsync(keywordDirectory, warmup);
-            return;
+            success = await _searchService!.ExecuteAsync(keywordDirectory, warmup);
         }
-
-        if (roll < normalizedSearchWeight + normalizedShortsWeight)
+        else if (roll < normalizedSearchWeight + normalizedShortsWeight)
         {
             _logger?.LogInformation("YouTube warmup selected Shorts interaction.");
-            bool success = await OpenShortsAsync(warmup);
+            success = await _shortsService!.ExecuteAsync(warmup, preferGuideMenu: false);
             if (!success)
             {
                 _logger?.LogInformation("Shorts interaction unavailable; falling back to home recommendation.");
-                await WatchFromHomeAsync(warmup);
+                success = await _homeService!.ExecuteAsync(warmup);
             }
-            return;
+        }
+        else
+        {
+            _logger?.LogInformation("YouTube warmup selected home recommendation interaction.");
+            success = await _homeService!.ExecuteAsync(warmup);
         }
 
-        _logger?.LogInformation("YouTube warmup selected home recommendation interaction (weight={Weight:0.00}).", homeWeight);
-        await WatchFromHomeAsync(warmup);
+        if (!success)
+        {
+            RegisterInteractionFailure();
+        }
+
+        return success;
     }
 
     private async Task<IPage> EnsurePageAsync()
@@ -422,6 +425,68 @@ internal class YouTubeWarmupService
         _keyboardHelper = new KeyboardHelper(_page);
         return _page;
     }
+
+    private void EnsureInteractionServices()
+    {
+        _videoPlayer ??= new VideoPlayerService(
+            EnsurePageAsync,
+            () => _mouseHelper,
+            () => _keyboardHelper,
+            _random,
+            _logger,
+            GetPlaybackPreferences,
+            RecordVideoWatch,
+            PauseAfterPlaybackAsync);
+
+        _recommendationService ??= new RecommendationChainService(
+            EnsurePageAsync,
+            () => _mouseHelper,
+            _random,
+            _logger,
+            _videoPlayer,
+            WaitForNavigationAsync);
+
+        _homeService ??= new HomeInteractionService(
+            EnsurePageAsync,
+            NavigateHomeAsync,
+            _videoPlayer,
+            _recommendationService,
+            WaitForNavigationAsync,
+            _random,
+            () => _mouseHelper,
+            _logger);
+
+        _shortsService ??= new ShortsInteractionService(
+            EnsurePageAsync,
+            EnsureOnYouTubeAsync,
+            GetBaseYouTubeDomain,
+            WaitForNavigationAsync,
+            _videoPlayer,
+            _random,
+            () => _mouseHelper,
+            _logger);
+
+        _searchService ??= new SearchInteractionService(
+            EnsurePageAsync,
+            EnsureOnYouTubeAsync,
+            async directory => await PickKeywordAsync(directory),
+            RegisterKeywordUsage,
+            FocusSearchBoxAsync,
+            ClearInputAsync,
+            WaitForNavigationAsync,
+            _videoPlayer,
+            _recommendationService,
+            _random,
+            () => _mouseHelper,
+            () => _keyboardHelper,
+            _logger,
+            async settings => await _homeService!.ExecuteAsync(settings));
+    }
+
+    private Task PauseAfterPlaybackAsync() => Task.Delay(_random.Next(400, 900));
+
+    private YouTubeWarmupService.IdentityPlaybackPreferences? GetPlaybackPreferences()
+        => _identityDocument?.Playback;
 
     private async Task EnsureOnYouTubeAsync(YouTubeWarmupSettings warmup)
     {
@@ -490,219 +555,6 @@ internal class YouTubeWarmupService
         return false;
     }
 
-    private async Task SearchAndWatchAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
-    {
-        var page = await EnsurePageAsync();
-        await EnsureOnYouTubeAsync(warmup);
-
-        string keyword = await PickKeywordAsync(keywordDirectory);
-        RegisterKeywordUsage(keyword);
-        _logger?.LogInformation(
-            "YouTube identity {Identity} searching for keyword '{Keyword}'.",
-            _identityKey,
-            keyword);
-
-        var input = await FocusSearchBoxAsync();
-        await ClearInputAsync(input);
-        await _keyboardHelper!.TypeLikeHumanAsync(input, keyword);
-        await Task.Delay(_random.Next(400, 1200));
-
-        double decision = _random.NextDouble();
-        string previousUrl = page.Url;
-        if (decision < 0.4)
-        {
-            var searchButton = page.Locator("button#search-icon-legacy");
-            if (await searchButton.CountAsync() > 0 && await searchButton.IsVisibleAsync())
-            {
-                await _mouseHelper!.MoveAndClickAsync(searchButton);
-            }
-            else
-            {
-                await input.PressAsync("Enter");
-            }
-        }
-        else if (decision < 0.75)
-        {
-            await input.PressAsync("Enter");
-        }
-        else
-        {
-            await _mouseHelper!.MoveAndClickAsync(input);
-            await input.PressAsync("Enter");
-        }
-
-        await WaitForNavigationAsync(page, previousUrl);
-
-        var videoTiles = page.Locator("ytd-video-renderer a#thumbnail, ytd-grid-video-renderer a#thumbnail");
-        if (await videoTiles.CountAsync() == 0)
-        {
-            _logger?.LogWarning("No YouTube search results were found.");
-            return;
-        }
-
-        int index = _random.Next(0, await videoTiles.CountAsync());
-        var target = videoTiles.Nth(index);
-        _logger?.LogInformation("Opening YouTube search result #{Index}.", index + 1);
-        await ScrollHelper.ScrollToElementAsync(page, target);
-        string beforeClickUrl = page.Url;
-        await _mouseHelper!.MoveAndClickAsync(target);
-
-        await WaitForNavigationAsync(page, beforeClickUrl);
-        var result = await WatchCurrentEntryAsync(
-            warmup,
-            context: "Search",
-            method: "SearchResult",
-            contextDetail: $"SearchResult#{index + 1}",
-            entryPoint: "Search",
-            keyword: keyword,
-            position: index + 1,
-            parent: null);
-        if (result != null)
-        {
-            await MaybeChainRecommendedVideosAsync(warmup, result);
-        }
-    }
-
-    private async Task WatchFromHomeAsync(YouTubeWarmupSettings warmup)
-    {
-        var page = await EnsurePageAsync();
-        await NavigateHomeAsync(warmup);
-
-        var richItems = page.Locator("#contents ytd-rich-item-renderer a#thumbnail");
-        int count = await richItems.CountAsync();
-        if (count == 0)
-        {
-            _logger?.LogWarning("No rich items on YouTube home page. Trying search fallback.");
-            await SearchAndWatchAsync(null, warmup);
-            return;
-        }
-
-        int index = _random.Next(0, count);
-        var target = richItems.Nth(index);
-        _logger?.LogInformation("Opening YouTube home recommendation #{Index} of {Total}.", index + 1, count);
-        await ScrollHelper.ScrollToElementAsync(page, target);
-        string beforeClickUrl = page.Url;
-        await _mouseHelper!.MoveAndClickAsync(target);
-        await WaitForNavigationAsync(page, beforeClickUrl);
-
-        var result = await WatchCurrentEntryAsync(
-            warmup,
-            context: "RecommendationHome",
-            method: "HomeRecommendation",
-            contextDetail: $"HomeRecommendation#{index + 1}",
-            entryPoint: "Home",
-            keyword: null,
-            position: index + 1,
-            parent: null);
-        if (result != null)
-        {
-            await MaybeChainRecommendedVideosAsync(warmup, result);
-        }
-    }
-
-    private async Task<bool> OpenShortsAsync(YouTubeWarmupSettings warmup, bool preferGuideMenu = false)
-    {
-        var page = await EnsurePageAsync();
-        await EnsureOnYouTubeAsync(warmup);
-
-        bool guideOpened = false;
-        if (preferGuideMenu)
-        {
-            guideOpened = await TryEnsureGuideMenuVisibleAsync(page);
-        }
-
-        var shortsLink = await TryFindShortsLinkAsync(page);
-        if (shortsLink == null || !await shortsLink.IsVisibleAsync())
-        {
-            if (!guideOpened)
-            {
-                guideOpened = await TryEnsureGuideMenuVisibleAsync(page);
-            }
-
-            shortsLink = await TryFindShortsLinkAsync(page);
-        }
-
-        if (shortsLink == null || !await shortsLink.IsVisibleAsync())
-        {
-            if (_random.NextDouble() < 0.15)
-            {
-                string baseDomain = GetBaseYouTubeDomain();
-                await page.GotoAsync($"{baseDomain.TrimEnd('/')}/shorts", new PageGotoOptions
-                {
-                    Timeout = 45000,
-                    WaitUntil = WaitUntilState.DOMContentLoaded
-                });
-                await Task.Delay(_random.Next(800, 1500));
-                return await WatchShortsSequenceAsync(warmup);
-            }
-
-            return false;
-        }
-
-        await _mouseHelper!.MoveAndClickAsync(shortsLink);
-        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-        await Task.Delay(_random.Next(1000, 2000));
-
-        return await WatchShortsSequenceAsync(warmup);
-    }
-
-    private async Task<bool> WatchShortsSequenceAsync(YouTubeWarmupSettings warmup)
-    {
-        var page = await EnsurePageAsync();
-        var shortsTiles = page.Locator("ytd-reel-video-renderer a#thumbnail, ytd-reel-item-renderer a#thumbnail");
-        int count = await shortsTiles.CountAsync();
-        if (count == 0)
-        {
-            _logger?.LogWarning("No shorts available after navigating to Shorts page.");
-            return false;
-        }
-
-        int index = _random.Next(0, count);
-        var target = shortsTiles.Nth(index);
-        _logger?.LogInformation("Opening YouTube short #{Index} of {Total}.", index + 1, count);
-        string beforeClickUrl = page.Url;
-        await _mouseHelper!.MoveAndClickAsync(target);
-        await WaitForNavigationAsync(page, beforeClickUrl);
-
-        int minSequence = Math.Max(1, warmup.MinShortSequenceLength);
-        int maxSequence = Math.Max(minSequence, warmup.MaxShortSequenceLength);
-        int sequenceCount = _random.Next(minSequence, maxSequence + 1);
-
-        VideoWatchResult? previous = null;
-        for (int i = 0; i < sequenceCount; i++)
-        {
-            string context = i == 0 ? "Shorts" : "ShortsContinuation";
-            string method = i == 0 ? "InitialShort" : "NextShort";
-            string detail = $"Shorts#{i + 1}";
-            string entryPoint = previous?.EntryPoint ?? "Shorts";
-
-            var result = await WatchShortAsync(
-                warmup,
-                context,
-                method,
-                detail,
-                entryPoint,
-                position: i + 1,
-                parent: previous);
-            if (result == null)
-            {
-                break;
-            }
-
-            previous = result;
-
-            if (i < sequenceCount - 1)
-            {
-                bool advanced = await AdvanceToNextShortAsync();
-                if (!advanced)
-                {
-                    break;
-                }
-            }
-        }
-
-        return true;
-    }
 
     private async Task<bool> AdvanceToNextShortAsync()
     {
@@ -733,324 +585,6 @@ internal class YouTubeWarmupService
         return false;
     }
 
-    private async Task<int?> MaybeAdjustVolumeAsync(IPage page)
-    {
-        var playback = _identityDocument?.Playback;
-        if (playback == null)
-        {
-            return null;
-        }
-
-        playback.MinVolumePercent = Math.Clamp(playback.MinVolumePercent, 0, 100);
-        playback.MaxVolumePercent = Math.Clamp(playback.MaxVolumePercent, 0, 100);
-        if (playback.MinVolumePercent > playback.MaxVolumePercent)
-        {
-            (playback.MinVolumePercent, playback.MaxVolumePercent) = (playback.MaxVolumePercent, playback.MinVolumePercent);
-        }
-
-        playback.VolumeAdjustmentChance = Math.Clamp(playback.VolumeAdjustmentChance, 0, 1);
-        if (playback.VolumeAdjustmentChance <= 0)
-        {
-            playback.VolumeAdjustmentChance = 0.6;
-        }
-
-        if (_random.NextDouble() > playback.VolumeAdjustmentChance)
-        {
-            return playback.LastVolumePercent;
-        }
-
-        double? currentVolume = null;
-        try
-        {
-            currentVolume = await page.EvaluateAsync<double?>("() => { const video = document.querySelector('video'); return video ? video.volume : null; }");
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to read current YouTube volume.");
-        }
-
-        int min = playback.MinVolumePercent;
-        int max = playback.MaxVolumePercent;
-        int targetPercent = min == max ? min : _random.Next(min, max + 1);
-        double targetVolume = Math.Clamp(targetPercent / 100.0, 0, 1);
-
-        if (currentVolume.HasValue && Math.Abs(currentVolume.Value - targetVolume) < 0.03 && _random.NextDouble() < 0.4)
-        {
-            int currentPercent = Math.Clamp((int)Math.Round(currentVolume.Value * 100), 0, 100);
-            playback.LastVolumePercent = currentPercent;
-            return currentPercent;
-        }
-
-        var videoLocator = page.Locator("video.html5-main-video, ytd-player video");
-        try
-        {
-            if (await videoLocator.CountAsync() > 0)
-            {
-                if (_mouseHelper != null)
-                {
-                    await _mouseHelper.MoveAndClickAsync(videoLocator.First);
-                }
-                else
-                {
-                    await videoLocator.First.ClickAsync();
-                }
-
-                await Task.Delay(_random.Next(120, 260));
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to focus video element before adjusting volume.");
-        }
-
-        bool usedKeyboard = _random.NextDouble() < 0.65;
-        if (usedKeyboard)
-        {
-            double startingVolume = currentVolume ?? (playback.LastVolumePercent.HasValue ? playback.LastVolumePercent.Value / 100.0 : 0.5);
-            double step = 0.05;
-            int steps = (int)Math.Round((targetVolume - startingVolume) / step);
-            string key = steps >= 0 ? "ArrowUp" : "ArrowDown";
-
-            for (int i = 0; i < Math.Abs(steps); i++)
-            {
-                await page.Keyboard.PressAsync(key);
-                await Task.Delay(_random.Next(70, 150));
-            }
-        }
-        else
-        {
-            try
-            {
-                await page.EvaluateAsync("(vol) => { const video = document.querySelector('video'); if (video) { video.volume = Math.min(1, Math.max(0, vol)); } }", targetVolume);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogDebug(ex, "Failed to set YouTube volume via script.");
-            }
-        }
-
-        double? finalVolume = null;
-        try
-        {
-            finalVolume = await page.EvaluateAsync<double?>("() => { const video = document.querySelector('video'); return video ? video.volume : null; }");
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to read final YouTube volume.");
-        }
-
-        int? finalPercent = finalVolume.HasValue
-            ? (int?)Math.Clamp((int)Math.Round(finalVolume.Value * 100), 0, 100)
-            : targetPercent;
-
-        playback.LastVolumePercent = finalPercent;
-        return finalPercent;
-    }
-
-    private async Task<VideoWatchResult?> WatchCurrentEntryAsync(
-        YouTubeWarmupSettings warmup,
-        string context,
-        string method,
-        string contextDetail,
-        string entryPoint,
-        string? keyword,
-        int? position,
-        VideoWatchResult? parent)
-    {
-        var page = await EnsurePageAsync();
-        var kind = YouTubeUrlHelper.GetVideoKind(page.Url);
-
-        return kind == YouTubeUrlHelper.YouTubeVideoKind.Short
-            ? await WatchShortAsync(
-                warmup,
-                context,
-                method,
-                contextDetail,
-                entryPoint,
-                position,
-                parent)
-            : await WatchVideoAsync(
-                warmup,
-                context,
-                method,
-                contextDetail,
-                entryPoint,
-                keyword,
-                position,
-                parent,
-                kind);
-    }
-
-    private async Task<VideoWatchResult?> WatchVideoAsync(
-        YouTubeWarmupSettings warmup,
-        string context,
-        string method,
-        string contextDetail,
-        string entryPoint,
-        string? keyword,
-        int? position,
-        VideoWatchResult? parent,
-        YouTubeUrlHelper.YouTubeVideoKind detectedKind)
-    {
-        var page = await EnsurePageAsync();
-        try
-        {
-            await WaitForStandardPlayerAsync(page);
-        }
-        catch
-        {
-            _logger?.LogWarning("Video element did not appear for context {Context}.", context);
-        }
-
-        await FocusPlayerAsync(page, detectedKind);
-        await MaybeSkipAdsAsync(page);
-
-        int? volumePercent = await MaybeAdjustVolumeAsync(page);
-        int planned = PlanWatchDuration(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
-        int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
-        var start = DateTimeOffset.Now;
-        var stopwatch = Stopwatch.StartNew();
-
-        await page.WaitForTimeoutAsync(actualTarget);
-
-        if (_random.NextDouble() < 0.3)
-        {
-            await page.Keyboard.PressAsync("Space");
-            await Task.Delay(_random.Next(800, 1500));
-            await page.Keyboard.PressAsync("Space");
-        }
-
-        if (_random.NextDouble() < 0.4)
-        {
-            await ScrollHelper.ScrollRandomAsync(page, _random.Next(1, 4));
-        }
-
-        double detailRoll = _random.NextDouble();
-        if (detailRoll < 0.25)
-        {
-            var showMore = await TryGetFirstVisibleLocatorAsync(
-                page,
-                "tp-yt-paper-button#expand",
-                "ytd-text-inline-expander tp-yt-paper-button#expand",
-                "ytd-expander tp-yt-paper-button#more");
-            if (showMore != null)
-            {
-                if (_mouseHelper != null)
-                {
-                    await _mouseHelper.MoveAndClickAsync(showMore);
-                }
-                else
-                {
-                    await showMore.ClickAsync();
-                }
-            }
-        }
-        else if (detailRoll < 0.35)
-        {
-            var collapse = await TryGetFirstVisibleLocatorAsync(
-                page,
-                "tp-yt-paper-button#collapse",
-                "ytd-expander tp-yt-paper-button#collapse");
-            if (collapse != null)
-            {
-                if (_mouseHelper != null)
-                {
-                    await _mouseHelper.MoveAndClickAsync(collapse);
-                }
-                else
-                {
-                    await collapse.ClickAsync();
-                }
-            }
-        }
-
-        stopwatch.Stop();
-
-        var result = new VideoWatchResult
-        {
-            Context = context,
-            ContextDetail = contextDetail,
-            EntryPoint = string.IsNullOrWhiteSpace(entryPoint) ? context : entryPoint,
-            Method = method,
-            ResultPosition = position,
-            Keyword = keyword,
-            Url = page.Url,
-            Title = await TryGetInnerTextAsync(page.Locator("h1 yt-formatted-string")),
-            ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-name a")),
-            PlannedWatchDurationMs = planned,
-            ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
-            StartedAt = start,
-            IsShort = false,
-            ParentVideoUrl = parent?.Url,
-            ParentVideoTitle = parent?.Title,
-            ParentContext = parent?.ContextDetail ?? parent?.Context,
-            VolumePercent = volumePercent
-        };
-
-        result.VideoType = YouTubeUrlHelper.GetVideoKind(result.Url);
-        result.IsShort = result.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short;
-
-        RecordVideoWatch(result);
-        return result;
-    }
-
-    private async Task<VideoWatchResult?> WatchShortAsync(
-        YouTubeWarmupSettings warmup,
-        string context,
-        string method,
-        string contextDetail,
-        string entryPoint,
-        int? position,
-        VideoWatchResult? parent)
-    {
-        var page = await EnsurePageAsync();
-        await WaitForShortPlayerAsync(page);
-        await FocusPlayerAsync(page, YouTubeUrlHelper.YouTubeVideoKind.Short);
-        await MaybeSkipAdsAsync(page);
-
-        int? volumePercent = await MaybeAdjustVolumeAsync(page);
-        int planned = PlanWatchDuration(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
-        int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
-        var start = DateTimeOffset.Now;
-        var stopwatch = Stopwatch.StartNew();
-
-        await page.WaitForTimeoutAsync(actualTarget);
-
-        if (_random.NextDouble() < 0.25)
-        {
-            await page.Keyboard.PressAsync("ArrowUp");
-            await page.Keyboard.PressAsync("ArrowDown");
-        }
-
-        stopwatch.Stop();
-
-        var result = new VideoWatchResult
-        {
-            Context = context,
-            ContextDetail = contextDetail,
-            EntryPoint = string.IsNullOrWhiteSpace(entryPoint) ? context : entryPoint,
-            Method = method,
-            ResultPosition = position,
-            Url = page.Url,
-            Title = await TryGetInnerTextAsync(page.Locator("#description h1, #info-contents h2, #shorts-player h1")),
-            ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-container a")),
-            PlannedWatchDurationMs = planned,
-            ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
-            StartedAt = start,
-            IsShort = true,
-            ParentVideoUrl = parent?.Url,
-            ParentVideoTitle = parent?.Title,
-            ParentContext = parent?.ContextDetail ?? parent?.Context,
-            VolumePercent = volumePercent
-        };
-
-        result.VideoType = YouTubeUrlHelper.GetVideoKind(result.Url);
-        result.IsShort = result.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short;
-
-        RecordVideoWatch(result);
-        return result;
-    }
-
     private async Task WaitForNavigationAsync(IPage page, string previousUrl)
     {
         try
@@ -1074,1020 +608,13 @@ internal class YouTubeWarmupService
         }
     }
 
-    private static async Task WaitForStandardPlayerAsync(IPage page)
-    {
-        try
-        {
-            await page.WaitForSelectorAsync(
-                "video.html5-main-video, ytd-player video",
-                new PageWaitForSelectorOptions { Timeout = 20000 });
-        }
-        catch
-        {
-            // ignore and let caller handle missing player
-        }
-    }
-
-    private static async Task WaitForShortPlayerAsync(IPage page)
-    {
-        try
-        {
-            await page.WaitForSelectorAsync(
-                "#shorts-player video, ytd-reel-video-renderer video, ytd-shorts-player-renderer video",
-                new PageWaitForSelectorOptions { Timeout = 20000 });
-        }
-        catch
-        {
-            // best effort
-        }
-    }
-
-    private async Task FocusPlayerAsync(IPage page, YouTubeUrlHelper.YouTubeVideoKind kind)
-    {
-        try
-        {
-            string[] selectors = kind == YouTubeUrlHelper.YouTubeVideoKind.Short
-                ? new[]
-                {
-                    "#shorts-player video",
-                    "#shorts-player",
-                    "ytd-reel-video-renderer video"
-                }
-                : new[]
-                {
-                    "video.html5-main-video",
-                    "ytd-player video",
-                    "#movie_player"
-                };
-
-            foreach (string selector in selectors)
-            {
-                var locator = page.Locator(selector);
-                if (await locator.CountAsync() == 0)
-                {
-                    continue;
-                }
-
-                var element = locator.First;
-                if (!await element.IsVisibleAsync())
-                {
-                    continue;
-                }
-
-                await element.FocusAsync();
-                if (_mouseHelper != null)
-                {
-                    await _mouseHelper.MoveToAsync(element, steps: 12, addJitter: true);
-                }
-
-                return;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to focus YouTube player.");
-        }
-    }
-
-    private async Task MaybeChainRecommendedVideosAsync(YouTubeWarmupSettings warmup, VideoWatchResult initialResult)
-    {
-        double probability = Math.Clamp(warmup.RecommendationChainProbability, 0, 1);
-        if (_random.NextDouble() > probability)
-        {
-            return;
-        }
-
-        _logger?.LogInformation(
-            "Evaluating recommendation chain after video {Url} (context={Context}).",
-            initialResult.Url ?? "unknown",
-            initialResult.Context);
-
-        int minChain = Math.Max(1, warmup.MinRecommendationChainLength);
-        int maxChain = Math.Max(minChain, warmup.MaxRecommendationChainLength);
-        int chainCount = _random.Next(minChain, maxChain + 1);
-
-        var page = await EnsurePageAsync();
-        var parent = initialResult;
-        for (int i = 0; i < chainCount; i++)
-        {
-            if (parent.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short)
-            {
-                if (!await TryNavigateShortContinuationAsync(page))
-                {
-                    break;
-                }
-
-                string beforeShortUrl = parent.Url ?? page.Url;
-                await WaitForNavigationAsync(page, beforeShortUrl);
-
-                var shortResult = await WatchCurrentEntryAsync(
-                    warmup,
-                    context: "RecommendationNext",
-                    method: "ShortsNavigation",
-                    contextDetail: $"ShortsChain#{i + 1}",
-                    entryPoint: parent.EntryPoint ?? "Recommendation",
-                    keyword: null,
-                    position: null,
-                    parent: parent);
-
-                if (shortResult == null)
-                {
-                    break;
-                }
-
-                parent = shortResult;
-                continue;
-            }
-
-            string previousUrl = page.Url;
-            bool useAutoplay = i == 0 && _random.NextDouble() < Math.Clamp(warmup.AutoplayFollowProbability, 0, 1);
-            bool navigated;
-            string method;
-            string contextDetail;
-            int? position = null;
-
-            if (useAutoplay)
-            {
-                navigated = await TriggerAutoplayAsync(page);
-                method = "Autoplay";
-                contextDetail = "AutoplayNext";
-            }
-            else
-            {
-                int? selection = await OpenRecommendedSidebarVideoAsync(page);
-                navigated = selection.HasValue;
-                method = "ManualSidebar";
-                if (!navigated)
-                {
-                    break;
-                }
-
-                position = selection!.Value + 1;
-                contextDetail = $"Sidebar#{position}";
-            }
-
-            if (!navigated)
-            {
-                break;
-            }
-
-            await WaitForNavigationAsync(page, previousUrl);
-
-            if (string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger?.LogDebug("Recommended navigation did not change URL. Ending chain early.");
-                break;
-            }
-
-            string recommendationContext = "RecommendationNext";
-
-            var result = await WatchCurrentEntryAsync(
-                warmup,
-                context: recommendationContext,
-                method: method,
-                contextDetail: contextDetail,
-                entryPoint: parent.EntryPoint ?? "Recommendation",
-                keyword: null,
-                position: position,
-                parent: parent);
-            if (result == null)
-            {
-                break;
-            }
-
-            parent = result;
-        }
-    }
-
-    private async Task<bool> TryNavigateShortContinuationAsync(IPage page)
-    {
-        try
-        {
-            string previousUrl = page.Url;
-            var downButton = page.Locator("#navigation-button-down button, #navigation-button-down tp-yt-paper-button, #navigation-button-down");
-            if (await downButton.CountAsync() > 0 && await downButton.First.IsVisibleAsync())
-            {
-                await _mouseHelper!.MoveAndClickAsync(downButton.First);
-            }
-            else
-            {
-                await page.Keyboard.PressAsync("ArrowDown");
-            }
-
-            for (int attempt = 0; attempt < 20; attempt++)
-            {
-                await Task.Delay(400);
-                if (!string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to navigate to next short during recommendation chain.");
-        }
-
-        return false;
-    }
-
-    private async Task<bool> TriggerAutoplayAsync(IPage page)
-    {
-        try
-        {
-            await Task.Delay(_random.Next(1800, 3200));
-            if (_random.NextDouble() < 0.6)
-            {
-                await page.Keyboard.PressAsync("Shift+N");
-            }
-            else
-            {
-                var nextButton = page.Locator("a[aria-label*='Next'], button[aria-label*='Next']");
-                if (await nextButton.CountAsync() > 0)
-                {
-                    await _mouseHelper!.MoveAndClickAsync(nextButton.First);
-                }
-                else
-                {
-                    await page.Keyboard.PressAsync("Shift+N");
-                }
-            }
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to trigger autoplay navigation.");
-            return false;
-        }
-    }
-
-    private async Task MaybeSkipAdsAsync(IPage page)
-    {
-        try
-        {
-            bool adDetected = false;
-            int? detectedDurationMs = null;
-
-            for (int attempt = 0; attempt < 12; attempt++)
-            {
-                adDetected = await page.EvaluateAsync<bool>(
-                    "() => document.querySelector('.ad-showing, .ytp-ad-player-overlay, .ytp-ad-overlay-slot') !== null");
-                if (adDetected)
-                {
-                    string? durationText = await page.EvaluateAsync<string?>(
-                        "() => document.querySelector('.ytp-ad-duration-remaining .ytp-time-duration, .ytp-ad-duration-remaining')?.textContent ?? null");
-                    detectedDurationMs = ParseDurationToMilliseconds(durationText);
-                    break;
-                }
-
-                await Task.Delay(350);
-            }
-
-            if (!adDetected)
-            {
-                return;
-            }
-
-            int dwellMs;
-            if (detectedDurationMs.HasValue && detectedDurationMs.Value <= 15000)
-            {
-                dwellMs = _random.Next(5000, 8000);
-            }
-            else if (detectedDurationMs.HasValue && detectedDurationMs.Value <= 30000)
-            {
-                dwellMs = _random.Next(5000, 15000);
-            }
-            else
-            {
-                dwellMs = _random.Next(6000, 16000);
-            }
-
-            await Task.Delay(dwellMs);
-
-            var skipSelectors = new[]
-            {
-                "button.ytp-ad-skip-button", // primary skip button
-                ".ytp-ad-skip-button.ytp-button", // legacy skip button style
-                "button.ytp-ad-skip-button-modern", // new UI variant
-                ".ytp-ad-overlay-close-button", // overlay ads
-                "button[aria-label*='Skip'], button[aria-label*='skip']",
-                "#skip-button .ytp-button"
-            };
-
-            for (int attempt = 0; attempt < 6; attempt++)
-            {
-                bool stillShowing = await page.EvaluateAsync<bool>(
-                    "() => document.querySelector('.ad-showing, .ytp-ad-player-overlay, .ytp-ad-overlay-slot') !== null");
-                if (!stillShowing)
-                {
-                    return;
-                }
-
-                foreach (string selector in skipSelectors)
-                {
-                    var skipButton = page.Locator(selector);
-                    if (await skipButton.CountAsync() == 0)
-                    {
-                        continue;
-                    }
-
-                    var target = skipButton.First;
-                    if (!await target.IsVisibleAsync())
-                    {
-                        continue;
-                    }
-
-                    _logger?.LogDebug("Attempting to skip YouTube ad using selector {Selector}.", selector);
-                    if (_mouseHelper != null)
-                    {
-                        await _mouseHelper.MoveAndClickAsync(target);
-                    }
-                    else
-                    {
-                        await target.ClickAsync(new LocatorClickOptions { Timeout = 2000 });
-                    }
-
-                    await Task.Delay(_random.Next(600, 1200));
-                    return;
-                }
-
-                await Task.Delay(_random.Next(500, 900));
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed while attempting to skip YouTube ads.");
-        }
-    }
-
-    private static int? ParseDurationToMilliseconds(string? durationText)
-    {
-        if (string.IsNullOrWhiteSpace(durationText))
-        {
-            return null;
-        }
-
-        durationText = durationText.Trim();
-        var parts = durationText.Split(':', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0)
-        {
-            return null;
-        }
-
-        int seconds = 0;
-        int multiplier = 1;
-
-        for (int i = parts.Length - 1; i >= 0; i--)
-        {
-            if (!int.TryParse(parts[i], out int value))
-            {
-                return null;
-            }
-
-            seconds += value * multiplier;
-            multiplier *= 60;
-        }
-
-        return seconds * 1000;
-    }
-
-    private async Task<int?> OpenRecommendedSidebarVideoAsync(IPage page)
-    {
-        try
-        {
-            var recTiles = page.Locator(
-                "#items > yt-lockup-view-model a#thumbnail, " +
-                "ytd-compact-video-renderer a#thumbnail, " +
-                "ytd-watch-next-secondary-results-renderer a#thumbnail");
-            int count = await recTiles.CountAsync();
-            if (count == 0)
-            {
-                return null;
-            }
-
-            int selectionCount = Math.Min(count, 6);
-            int index = _random.Next(0, selectionCount);
-            var target = recTiles.Nth(index);
-            await ScrollHelper.ScrollToElementAsync(page, target);
-            await _mouseHelper!.MoveAndClickAsync(target);
-            return index;
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to open recommended video from sidebar.");
-            return null;
-        }
-    }
-
-    private int PlanWatchDuration(int min, int max)
-    {
-        if (min >= max)
-        {
-            return min;
-        }
-
-        double roll = _random.NextDouble();
-        int range = max - min;
-        int shortUpper = min + (int)(range * 0.2);
-        int mediumUpper = min + (int)(range * 0.7);
-
-        if (roll < 0.15)
-        {
-            return _random.Next(min, shortUpper + 1);
-        }
-
-        if (roll < 0.85)
-        {
-            return _random.Next(shortUpper, mediumUpper + 1);
-        }
-
-        return _random.Next(Math.Max(mediumUpper, min), max + 1);
-    }
-
-    private int ApplyWatchDurationJitter(int planned, int min, int max)
-    {
-        double jitter = 0.9 + (_random.NextDouble() * 0.3); // 0.9x - 1.2x
-        int adjusted = (int)(planned * jitter);
-        return Math.Clamp(adjusted, min, max);
-    }
-
-    private async Task<string> TryGetInnerTextAsync(ILocator locator)
-    {
-        try
-        {
-            if (await locator.CountAsync() == 0)
-            {
-                return string.Empty;
-            }
-
-            string? text = await locator.First.InnerTextAsync();
-            return text?.Trim() ?? string.Empty;
-        }
-        catch
-        {
-            return string.Empty;
-        }
-    }
-
-    private async Task NavigateHomeAsync(YouTubeWarmupSettings warmup)
-    {
-        var page = await EnsurePageAsync();
-        string domain = ChooseDomain(warmup);
-        SetActiveDomain(domain);
-        if (!page.Url.StartsWith(domain, StringComparison.OrdinalIgnoreCase))
-        {
-            _logger?.LogInformation("Navigating to YouTube home domain {Domain}.", domain);
-            await page.GotoAsync(domain, new PageGotoOptions
-            {
-                Timeout = 60000,
-                WaitUntil = WaitUntilState.DOMContentLoaded
-            });
-            await Task.Delay(_random.Next(800, 1600));
-            return;
-        }
-
-        var homeLink = page.Locator("ytd-mini-guide-entry-renderer a[title='Home'], ytd-mini-guide-entry-renderer:nth-child(1) a");
-        if (await homeLink.IsVisibleAsync())
-        {
-            await _mouseHelper!.MoveAndClickAsync(homeLink);
-            await Task.Delay(_random.Next(800, 1600));
-        }
-    }
-
-    private async Task<ILocator> FocusSearchBoxAsync()
-    {
-        var page = await EnsurePageAsync();
-        var input = page.Locator("input#search, input[name='search_query']");
-        await input.WaitForAsync(new LocatorWaitForOptions { Timeout = 20000 });
-
-        bool isFocused = false;
-        try
-        {
-            isFocused = await input.EvaluateAsync<bool>("el => document.activeElement === el");
-        }
-        catch
-        {
-            isFocused = false;
-        }
-
-        if (!isFocused)
-        {
-            await _mouseHelper!.MoveAndClickAsync(input);
-        }
-
-        return input;
-    }
-
-    private async Task ClearInputAsync(ILocator input)
-    {
-        string value = string.Empty;
-        try
-        {
-            value = await input.InputValueAsync() ?? string.Empty;
-        }
-        catch
-        {
-            value = string.Empty;
-        }
-
-        if (string.IsNullOrEmpty(value))
-        {
-            return;
-        }
-
-        if (_random.NextDouble() < 0.6)
-        {
-            await _page!.Keyboard.PressAsync("Control+A");
-            await Task.Delay(_random.Next(80, 200));
-            await _page.Keyboard.PressAsync("Backspace");
-        }
-        else
-        {
-            await _keyboardHelper!.BackspaceAsync(value.Length, fastCorrection: true);
-        }
-    }
-
-
-    private async Task<string> PickKeywordAsync(string? keywordDirectory)
-    {
-        if (_identityKeywords.Count > 0)
-        {
-            if (_identityDocument?.Keywords != null)
-            {
-                var usageLookup = (_identityDocument.Keywords.UsedHistory ?? new List<KeywordUsageRecord>())
-                    .GroupBy(record => record.Keyword, StringComparer.OrdinalIgnoreCase)
-                    .Select(group => group.OrderByDescending(r => r.LastUsed ?? DateTimeOffset.MinValue).First())
-                    .ToDictionary(record => record.Keyword, record => record, StringComparer.OrdinalIgnoreCase);
-
-                var ranked = _identityKeywords
-                    .Select(keyword =>
-                    {
-                        usageLookup.TryGetValue(keyword, out var record);
-                        int usage = record?.TimesUsed ?? 0;
-                        DateTimeOffset lastUsed = record?.LastUsed ?? DateTimeOffset.MinValue;
-                        return new { keyword, usage, lastUsed };
-                    })
-                    .OrderBy(item => item.usage)
-                    .ThenBy(item => item.lastUsed)
-                    .ThenBy(_ => _random.NextDouble())
-                    .FirstOrDefault();
-
-                if (ranked != null)
-                {
-                    return ranked.keyword;
-                }
-            }
-
-            return _identityKeywords[_random.Next(_identityKeywords.Count)];
-        }
-
-        if (!string.IsNullOrWhiteSpace(keywordDirectory) && Directory.Exists(keywordDirectory))
-        {
-            try
-            {
-                var files = Directory.GetFiles(keywordDirectory, "*.txt");
-                if (files.Length > 0)
-                {
-                    var file = files[_random.Next(files.Length)];
-                    var keywords = (await File.ReadAllLinesAsync(file))
-                        .Select(line => line.Trim())
-                        .Where(line => !string.IsNullOrWhiteSpace(line))
-                        .ToArray();
-
-                    if (keywords.Length > 0)
-                    {
-                        return keywords[_random.Next(keywords.Length)];
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Falling back to default YouTube keywords.");
-            }
-        }
-
-        return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
-    }
-
-    private async Task EnsureIdentityAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, string? profileKey)
-    {
-        if (_identityDocument != null && _identityKeywords.Count > 0)
-        {
-            return;
-        }
-
-        _identityKey = string.IsNullOrWhiteSpace(profileKey) ? "default" : profileKey;
-        string baseDirectory = string.IsNullOrWhiteSpace(warmup.IdentityCacheDirectory)
-            ? Path.Combine(AppContext.BaseDirectory, "youtube-identities")
-            : Path.GetFullPath(warmup.IdentityCacheDirectory);
-
-        Directory.CreateDirectory(baseDirectory);
-        string safeKey = SanitizeFileName(_identityKey);
-        _identityDirectory = Path.Combine(baseDirectory, safeKey);
-        Directory.CreateDirectory(_identityDirectory);
-        _sessionsDirectory = Path.Combine(_identityDirectory, "sessions");
-        Directory.CreateDirectory(_sessionsDirectory);
-        _identityPath = Path.Combine(_identityDirectory, "identity.json");
-
-        YouTubeIdentityDocument? document = null;
-        if (File.Exists(_identityPath))
-        {
-            try
-            {
-                document = JsonSerializer.Deserialize<YouTubeIdentityDocument>(await File.ReadAllTextAsync(_identityPath));
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to read YouTube identity document from {Path}. Rebuilding.", _identityPath);
-            }
-        }
-
-        bool updated = false;
-        if (document == null)
-        {
-            document = await CreateNewIdentityDocumentAsync(keywordDirectory, warmup);
-            updated = true;
-            _logger?.LogInformation(
-                "Created YouTube identity {Identity} with {KeywordCount} keywords (sources={Sources}).",
-                _identityKey,
-                document.Keywords.SeedList.Count,
-                document.SourceFiles.Count == 0 ? "fallback" : string.Join(",", document.SourceFiles));
-        }
-
-        document.Profile ??= new IdentityProfileInfo();
-        if (!string.Equals(document.Profile.ProfileId, _identityKey, StringComparison.Ordinal))
-        {
-            document.Profile.ProfileId = _identityKey;
-            updated = true;
-        }
-
-        if (string.IsNullOrWhiteSpace(document.Profile.Persona) && !string.IsNullOrWhiteSpace(warmup.Persona))
-        {
-            document.Profile.Persona = warmup.Persona;
-            updated = true;
-        }
-        if (string.IsNullOrWhiteSpace(document.Profile.Region) && !string.IsNullOrWhiteSpace(warmup.Region))
-        {
-            document.Profile.Region = warmup.Region;
-            updated = true;
-        }
-        if (string.IsNullOrWhiteSpace(document.Profile.Language) && !string.IsNullOrWhiteSpace(warmup.Language))
-        {
-            document.Profile.Language = warmup.Language;
-            updated = true;
-        }
-
-        if (string.IsNullOrWhiteSpace(document.Profile.Domain) && warmup.Domains?.Length > 0)
-        {
-            document.Profile.Domain = warmup.Domains[0];
-            updated = true;
-        }
-
-        string configuredTimezone = warmup.Timezone ?? TimeZoneInfo.Local.Id;
-        if (string.IsNullOrWhiteSpace(document.Profile.Timezone) || !string.Equals(document.Profile.Timezone, configuredTimezone, StringComparison.Ordinal))
-        {
-            document.Profile.Timezone = configuredTimezone;
-            updated = true;
-        }
-
-        if (warmup.Behaviors != null && warmup.Behaviors.Length > 0 && (document.Profile.Behaviors == null || document.Profile.Behaviors.Length == 0))
-        {
-            document.Profile.Behaviors = warmup.Behaviors;
-            updated = true;
-        }
-
-        document.Keywords ??= new KeywordSection();
-        document.Keywords.SeedList ??= new List<string>();
-        document.Keywords.UsedHistory ??= new List<KeywordUsageRecord>();
-        document.Keywords.KeywordHistory ??= new List<KeywordVideoRecord>();
-
-        if (document.Keywords.SeedList.Count == 0)
-        {
-            var (keywords, sources) = await BuildIdentityKeywordsAsync(keywordDirectory, warmup);
-            if (keywords.Count == 0)
-            {
-                keywords.AddRange(FallbackKeywords);
-            }
-
-            document.Keywords.SeedList = keywords;
-            document.SourceFiles = sources;
-            updated = true;
-        }
-
-        document.SourceFiles ??= new List<string>();
-        if (document.Playback == null)
-        {
-            document.Playback = CreatePlaybackPreferences();
-            updated = true;
-        }
-        if (document.Playback.MinVolumePercent < 0 || document.Playback.MinVolumePercent > 100)
-        {
-            document.Playback.MinVolumePercent = 20;
-            updated = true;
-        }
-        if (document.Playback.MaxVolumePercent < 0 || document.Playback.MaxVolumePercent > 100)
-        {
-            document.Playback.MaxVolumePercent = 80;
-            updated = true;
-        }
-        if (document.Playback.MinVolumePercent > document.Playback.MaxVolumePercent)
-        {
-            (document.Playback.MinVolumePercent, document.Playback.MaxVolumePercent) = (document.Playback.MaxVolumePercent, document.Playback.MinVolumePercent);
-            updated = true;
-        }
-        if (document.Playback.VolumeAdjustmentChance <= 0 || document.Playback.VolumeAdjustmentChance > 1)
-        {
-            document.Playback.VolumeAdjustmentChance = 0.6;
-            updated = true;
-        }
-        else
-        {
-            double clampedChance = Math.Clamp(document.Playback.VolumeAdjustmentChance, 0, 1);
-            if (!document.Playback.VolumeAdjustmentChance.Equals(clampedChance))
-            {
-                document.Playback.VolumeAdjustmentChance = clampedChance;
-                updated = true;
-            }
-        }
-
-        document.Stats ??= new IdentityStats();
-        document.Stats.SourceDistribution ??= new SourceBreakdown();
-
-        _identityDocument = document;
-        _identityKeywords.Clear();
-        _identityKeywords.AddRange(document.Keywords.SeedList);
-
-        if (_identityKeywords.Count == 0)
-        {
-            _identityKeywords.AddRange(FallbackKeywords);
-            document.Keywords.SeedList.AddRange(FallbackKeywords);
-            updated = true;
-        }
-
-        if (updated)
-        {
-            await SaveIdentityAsync();
-        }
-    }
-
-    private IdentityPlaybackPreferences CreatePlaybackPreferences()
-    {
-        int min = _random.Next(10, 41);
-        int maxLowerBound = Math.Max(min + 15, 55);
-        maxLowerBound = Math.Min(maxLowerBound, 95);
-        int max = _random.Next(maxLowerBound, 101);
-        if (max < min)
-        {
-            max = Math.Min(90, min + 10);
-        }
-
-        double chance = 0.45 + _random.NextDouble() * 0.35;
-
-        return new IdentityPlaybackPreferences
-        {
-            MinVolumePercent = Math.Clamp(min, 0, 100),
-            MaxVolumePercent = Math.Clamp(Math.Max(max, min + 5), 0, 100),
-            VolumeAdjustmentChance = Math.Clamp(chance, 0.1, 0.95)
-        };
-    }
-
-    private async Task<YouTubeIdentityDocument> CreateNewIdentityDocumentAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
-    {
-        var (keywords, sources) = await BuildIdentityKeywordsAsync(keywordDirectory, warmup);
-        if (keywords.Count == 0)
-        {
-            keywords.AddRange(FallbackKeywords);
-        }
-
-        var distinctKeywords = keywords
-            .Where(keyword => !string.IsNullOrWhiteSpace(keyword))
-            .Select(keyword => keyword.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        var profile = new IdentityProfileInfo
-        {
-            ProfileId = _identityKey,
-            Persona = string.IsNullOrWhiteSpace(warmup.Persona) ? "Generalist" : warmup.Persona,
-            Region = string.IsNullOrWhiteSpace(warmup.Region) ? "Global" : warmup.Region,
-            Language = string.IsNullOrWhiteSpace(warmup.Language) ? "en-US" : warmup.Language,
-            Domain = warmup.Domains?.FirstOrDefault() ?? "https://www.youtube.com",
-            Timezone = warmup.Timezone ?? TimeZoneInfo.Local.Id,
-            CreatedAt = DateTimeOffset.UtcNow,
-            LastUpdated = DateTimeOffset.UtcNow,
-            Behaviors = warmup.Behaviors ?? Array.Empty<string>()
-        };
-
-        return new YouTubeIdentityDocument
-        {
-            Profile = profile,
-            Keywords = new KeywordSection
-            {
-                SeedList = distinctKeywords,
-                UsedHistory = new List<KeywordUsageRecord>(),
-                KeywordHistory = new List<KeywordVideoRecord>()
-            },
-            Stats = new IdentityStats
-            {
-                LastUpdated = DateTimeOffset.UtcNow,
-                SourceDistribution = new SourceBreakdown()
-            },
-            Playback = CreatePlaybackPreferences(),
-            SourceFiles = sources
-        };
-    }
-
-    private async Task<(List<string> Keywords, List<string> Sources)> BuildIdentityKeywordsAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
-    {
-        var keywords = new List<string>();
-        var sources = new List<string>();
-
-        if (!string.IsNullOrWhiteSpace(keywordDirectory) && Directory.Exists(keywordDirectory))
-        {
-            try
-            {
-                var files = Directory.GetFiles(keywordDirectory, "*.txt");
-                if (files.Length > 0)
-                {
-                    int selectionCount = Math.Clamp(warmup.IdentityKeywordFileCount, 1, files.Length);
-                    var selected = files.OrderBy(_ => _random.NextDouble()).Take(selectionCount).ToArray();
-
-                    foreach (var file in selected)
-                    {
-                        var fileKeywords = (await File.ReadAllLinesAsync(file))
-                            .Select(line => line.Trim())
-                            .Where(line => !string.IsNullOrWhiteSpace(line))
-                            .ToArray();
-
-                        if (fileKeywords.Length > 0)
-                        {
-                            keywords.AddRange(fileKeywords);
-                            sources.Add(Path.GetFileName(file));
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to build identity keywords from directory {Directory}.", keywordDirectory);
-            }
-        }
-
-        if (keywords.Count > 0)
-        {
-            keywords = keywords
-                .Where(keyword => !string.IsNullOrWhiteSpace(keyword))
-                .Select(keyword => keyword.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-        }
-
-        return (keywords, sources);
-    }
-
-    private void RegisterKeywordUsage(string keyword)
-    {
-        if (_identityDocument?.Keywords == null)
-        {
-            return;
-        }
-
-        var usage = _identityDocument.Keywords.UsedHistory
-            .FirstOrDefault(record => string.Equals(record.Keyword, keyword, StringComparison.OrdinalIgnoreCase));
-        if (usage == null)
-        {
-            usage = new KeywordUsageRecord
-            {
-                Keyword = keyword,
-                TimesUsed = 1,
-                LastUsed = DateTimeOffset.UtcNow
-            };
-            _identityDocument.Keywords.UsedHistory.Add(usage);
-        }
-        else
-        {
-            usage.TimesUsed++;
-            usage.LastUsed = DateTimeOffset.UtcNow;
-        }
-    }
-
-    private void UpdateKeywordHistory(VideoWatchResult result)
-    {
-        if (_identityDocument?.Keywords == null || string.IsNullOrWhiteSpace(result.Keyword) || string.IsNullOrWhiteSpace(result.Url))
-        {
-            return;
-        }
-
-        var history = _identityDocument.Keywords.KeywordHistory;
-        var existing = history.FirstOrDefault(item =>
-            string.Equals(item.Keyword, result.Keyword, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(item.VideoUrl, result.Url, StringComparison.OrdinalIgnoreCase));
-
-        if (existing == null)
-        {
-            history.Add(new KeywordVideoRecord
-            {
-                Keyword = result.Keyword!,
-                VideoUrl = result.Url!,
-                WatchedMs = result.ActualWatchDurationMs,
-                WatchedAt = result.StartedAt,
-                VideoType = result.VideoType.ToString(),
-                VolumePercent = result.VolumePercent
-            });
-        }
-        else
-        {
-            existing.WatchedMs = result.ActualWatchDurationMs;
-            existing.WatchedAt = result.StartedAt;
-            existing.VideoType = result.VideoType.ToString();
-            existing.VolumePercent = result.VolumePercent;
-        }
-
-        const int maxHistory = 200;
-        if (history.Count > maxHistory)
-        {
-            int remove = history.Count - maxHistory;
-            history.RemoveRange(0, Math.Min(remove, history.Count));
-        }
-    }
-
-    private void RecordVideoWatch(VideoWatchResult result)
-    {
-        string? rawTitle = string.IsNullOrWhiteSpace(result.Title) ? null : result.Title;
-        string? rawChannel = string.IsNullOrWhiteSpace(result.ChannelName) ? null : result.ChannelName;
-        string title = rawTitle ?? "(unknown)";
-        string channel = rawChannel ?? "(unknown)";
-
-        _logger?.LogInformation(
-            "YouTube watch identity={Identity} entry={Entry} context={Context} detail={Detail} method={Method} url={Url} title={Title} channel={Channel} type={Type} planned_ms={Planned} actual_ms={Actual} started={Started:o} short={IsShort} volume={Volume} parent={Parent}.",
-            _identityKey,
-            result.EntryPoint,
-            result.Context,
-            result.ContextDetail,
-            result.Method,
-            result.Url ?? "unknown",
-            title,
-            channel,
-            result.VideoType,
-            result.PlannedWatchDurationMs,
-            result.ActualWatchDurationMs,
-            result.StartedAt,
-            result.IsShort,
-            result.VolumePercent,
-            result.ParentVideoUrl ?? "none");
-
-        var interaction = new SessionInteraction
-        {
-            Context = result.Context,
-            ContextDetail = result.ContextDetail,
-            EntryPoint = string.IsNullOrWhiteSpace(result.EntryPoint) ? result.Context : result.EntryPoint,
-            Method = result.Method,
-            ResultPosition = result.ResultPosition,
-            Keyword = result.Keyword,
-            VideoUrl = result.Url,
-            Title = rawTitle,
-            ChannelName = rawChannel,
-            PlannedWatchMs = result.PlannedWatchDurationMs,
-            ActualWatchMs = result.ActualWatchDurationMs,
-            StartedAt = result.StartedAt,
-            IsShort = result.IsShort,
-            ParentVideo = result.ParentVideoUrl,
-            ParentVideoTitle = result.ParentVideoTitle,
-            ParentContext = result.ParentContext,
-            VideoType = result.VideoType.ToString(),
-            VolumePercent = result.VolumePercent
-        };
-
-        _sessionInteractions.Add(interaction);
-        _sessionTotalWatchTimeMs += result.ActualWatchDurationMs;
-
-        if (IsBounce(result))
-        {
-            _sessionBounceCount++;
-        }
-
-        string entryPoint = interaction.EntryPoint;
-        if (!_sessionSourceCounts.ContainsKey(entryPoint))
-        {
-            _sessionSourceCounts[entryPoint] = 0;
-        }
-        _sessionSourceCounts[entryPoint]++;
-
-        if (result.VolumePercent.HasValue && _identityDocument?.Playback != null)
-        {
-            _identityDocument.Playback.LastVolumePercent = Math.Clamp(result.VolumePercent.Value, 0, 100);
-        }
-
-        UpdateKeywordHistory(result);
-    }
-
     private void BeginSession()
     {
         _sessionInteractions.Clear();
         _sessionSourceCounts.Clear();
         _sessionTotalWatchTimeMs = 0;
         _sessionBounceCount = 0;
+        _sessionFailureCount = 0;
         _sessionStart = DateTimeOffset.UtcNow;
         _sessionId = Guid.NewGuid().ToString("N");
     }
@@ -2109,6 +636,7 @@ internal class YouTubeWarmupService
                 : 0,
             BounceCount = _sessionBounceCount,
             DeepChain = _sessionInteractions.Count >= 3,
+            FailedInteractions = _sessionFailureCount,
             Sources = new SessionSourceBreakdown
             {
                 Search = _sessionSourceCounts.TryGetValue("Search", out var search) ? search : 0,
@@ -2143,13 +671,14 @@ internal class YouTubeWarmupService
         }
 
         _logger?.LogInformation(
-            "YouTube warmup session {SessionId} summary: videos={Videos} total_ms={Total} avg_ms={Average:0} bounce={Bounce} deep_chain={Deep} sources(search={Search}, home={Home}, shorts={Shorts}).",
+            "YouTube warmup session {SessionId} summary: videos={Videos} total_ms={Total} avg_ms={Average:0} bounce={Bounce} deep_chain={Deep} fails={Fails} sources(search={Search}, home={Home}, shorts={Shorts}).",
             _sessionId,
             summary.VideosWatched,
             summary.TotalWatchTimeMs,
             summary.AverageWatchTimeMs,
             summary.BounceCount,
             summary.DeepChain,
+            summary.FailedInteractions,
             summary.Sources.Search,
             summary.Sources.Home,
             summary.Sources.Shorts);
@@ -2193,6 +722,11 @@ internal class YouTubeWarmupService
             stats.SourceDistribution.HomePercent = (double)stats.SourceDistribution.HomeCount / totalVideos * 100;
             stats.SourceDistribution.ShortsPercent = (double)stats.SourceDistribution.ShortsCount / totalVideos * 100;
         }
+
+        int denominator = stats.TotalVideosWatched + Math.Max(0, stats.FailedInteractions);
+        stats.ErrorRate = denominator > 0
+            ? (double)stats.FailedInteractions / denominator * 100
+            : 0;
 
         stats.LastUpdated = endedAt;
         _identityDocument.Profile.LastUpdated = endedAt;

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
@@ -20,7 +23,10 @@ internal class YouTubeWarmupService
     private KeyboardHelper? _keyboardHelper;
     private bool _isFirstRun = true;
 
-    private static readonly string[] FallbackKeywords = new[]
+    private IdentityProfile? _identityProfile;
+    private List<string>? _identityKeywords;
+
+    private static readonly string[] FallbackKeywords =
     {
         "daily vlog",
         "music playlist",
@@ -30,13 +36,41 @@ internal class YouTubeWarmupService
         "gaming highlights"
     };
 
+    private sealed class IdentityProfile
+    {
+        public string IdentityKey { get; set; } = string.Empty;
+        public List<string> Keywords { get; set; } = new();
+        public List<string> SourceFiles { get; set; } = new();
+        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    }
+
+    private sealed class VideoWatchResult
+    {
+        public string Context { get; set; } = string.Empty;
+        public string Method { get; set; } = string.Empty;
+        public string? Url { get; set; }
+            = string.Empty;
+        public string? Title { get; set; }
+            = string.Empty;
+        public string? ChannelName { get; set; }
+            = string.Empty;
+        public int PlannedWatchDurationMs { get; set; }
+            = 0;
+        public int ActualWatchDurationMs { get; set; }
+            = 0;
+        public DateTimeOffset StartedAt { get; set; }
+            = DateTimeOffset.UtcNow;
+        public bool IsShort { get; set; }
+            = false;
+    }
+
     public YouTubeWarmupService(IBrowserContext context, ILogger<YouTubeWarmupService>? logger = null)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _logger = logger;
     }
 
-    public async Task RunWarmupAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    public async Task RunWarmupAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, string? profileKey)
     {
         if (warmup is null)
         {
@@ -68,6 +102,8 @@ internal class YouTubeWarmupService
         {
             warmup.MinShortWatchMilliseconds = Math.Min(8000, warmup.MaxShortWatchMilliseconds);
         }
+
+        await EnsureIdentityKeywordsAsync(keywordDirectory, warmup, profileKey);
 
         int completed = 0;
         while (true)
@@ -183,7 +219,10 @@ internal class YouTubeWarmupService
         await EnsureOnYouTubeAsync(warmup);
 
         string keyword = await PickKeywordAsync(keywordDirectory);
-        _logger?.LogInformation("Searching YouTube for '{Keyword}'.", keyword);
+        _logger?.LogInformation(
+            "YouTube identity {Identity} searching for keyword '{Keyword}'.",
+            _identityProfile?.IdentityKey ?? "default",
+            keyword);
 
         var input = await FocusSearchBoxAsync();
         await ClearInputAsync(input);
@@ -230,7 +269,11 @@ internal class YouTubeWarmupService
         await _mouseHelper!.MoveAndClickAsync(target);
 
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await WatchVideoAsync(warmup);
+        var result = await WatchVideoAsync(warmup, "Search", "SearchResult");
+        if (result != null)
+        {
+            await MaybeChainRecommendedVideosAsync(warmup, result);
+        }
     }
 
     private async Task WatchFromHomeAsync(YouTubeWarmupSettings warmup)
@@ -253,7 +296,11 @@ internal class YouTubeWarmupService
         await ScrollHelper.ScrollToElementAsync(page, target);
         await _mouseHelper!.MoveAndClickAsync(target);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await WatchVideoAsync(warmup);
+        var result = await WatchVideoAsync(warmup, "Home", "HomeRecommendation");
+        if (result != null)
+        {
+            await MaybeChainRecommendedVideosAsync(warmup, result);
+        }
     }
 
     private async Task<bool> OpenShortsAsync(YouTubeWarmupSettings warmup)
@@ -281,6 +328,12 @@ internal class YouTubeWarmupService
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
         await Task.Delay(_random.Next(1000, 2000));
 
+        return await WatchShortsSequenceAsync(warmup);
+    }
+
+    private async Task<bool> WatchShortsSequenceAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
         var shortsTiles = page.Locator("ytd-reel-video-renderer a#thumbnail, ytd-reel-item-renderer a#thumbnail");
         int count = await shortsTiles.CountAsync();
         if (count == 0)
@@ -293,16 +346,79 @@ internal class YouTubeWarmupService
         var target = shortsTiles.Nth(index);
         _logger?.LogInformation("Opening YouTube short #{Index} of {Total}.", index + 1, count);
         await _mouseHelper!.MoveAndClickAsync(target);
-        await page.WaitForTimeoutAsync(_random.Next(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds + 1));
+        await Task.Delay(_random.Next(800, 1500));
+
+        int minSequence = Math.Max(1, warmup.MinShortSequenceLength);
+        int maxSequence = Math.Max(minSequence, warmup.MaxShortSequenceLength);
+        int sequenceCount = _random.Next(minSequence, maxSequence + 1);
+
+        for (int i = 0; i < sequenceCount; i++)
+        {
+            var result = await WatchShortAsync(warmup, i == 0 ? "Shorts" : "ShortsContinuation", i == 0 ? "InitialShort" : "NextShort");
+            if (result == null)
+            {
+                break;
+            }
+
+            if (i < sequenceCount - 1)
+            {
+                bool advanced = await AdvanceToNextShortAsync();
+                if (!advanced)
+                {
+                    break;
+                }
+            }
+        }
+
         return true;
     }
 
-    private async Task WatchVideoAsync(YouTubeWarmupSettings warmup)
+    private async Task<bool> AdvanceToNextShortAsync()
     {
         var page = await EnsurePageAsync();
-        int watchMs = _random.Next(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds + 1);
-        _logger?.LogInformation("Watching YouTube video for approximately {Seconds:0.0} seconds.", watchMs / 1000.0);
-        await page.WaitForTimeoutAsync(watchMs);
+        try
+        {
+            if (_random.NextDouble() < 0.55)
+            {
+                await page.Keyboard.PressAsync("ArrowDown");
+                await Task.Delay(_random.Next(600, 1000));
+                return true;
+            }
+
+            var nextButton = page.Locator("button[aria-label*='Next'], button[aria-label*='Tiếp'], button[aria-label*='Sau']");
+            if (await nextButton.CountAsync() > 0 && await nextButton.First.IsEnabledAsync())
+            {
+                await _mouseHelper!.MoveAndClickAsync(nextButton.First);
+                await Task.Delay(_random.Next(600, 1000));
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to advance to next short.");
+        }
+
+        return false;
+    }
+
+    private async Task<VideoWatchResult?> WatchVideoAsync(YouTubeWarmupSettings warmup, string context, string method)
+    {
+        var page = await EnsurePageAsync();
+        try
+        {
+            await page.WaitForSelectorAsync("ytd-player video", new PageWaitForSelectorOptions { Timeout = 20000 });
+        }
+        catch
+        {
+            _logger?.LogWarning("Video element did not appear for context {Context}.", context);
+        }
+
+        int planned = PlanWatchDuration(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
+        int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
+        var start = DateTimeOffset.Now;
+        var stopwatch = Stopwatch.StartNew();
+
+        await page.WaitForTimeoutAsync(actualTarget);
 
         if (_random.NextDouble() < 0.3)
         {
@@ -323,6 +439,247 @@ internal class YouTubeWarmupService
             {
                 await _mouseHelper!.MoveAndClickAsync(showMore);
             }
+        }
+
+        stopwatch.Stop();
+
+        var result = new VideoWatchResult
+        {
+            Context = context,
+            Method = method,
+            Url = page.Url,
+            Title = await TryGetInnerTextAsync(page.Locator("h1 yt-formatted-string")),
+            ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-name a")),
+            PlannedWatchDurationMs = planned,
+            ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
+            StartedAt = start,
+            IsShort = false
+        };
+
+        LogVideoWatch(result);
+        return result;
+    }
+
+    private async Task<VideoWatchResult?> WatchShortAsync(YouTubeWarmupSettings warmup, string context, string method)
+    {
+        var page = await EnsurePageAsync();
+        int planned = PlanWatchDuration(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
+        int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
+        var start = DateTimeOffset.Now;
+        var stopwatch = Stopwatch.StartNew();
+
+        await page.WaitForTimeoutAsync(actualTarget);
+
+        if (_random.NextDouble() < 0.25)
+        {
+            await page.Keyboard.PressAsync("ArrowUp");
+            await page.Keyboard.PressAsync("ArrowDown");
+        }
+
+        stopwatch.Stop();
+
+        var result = new VideoWatchResult
+        {
+            Context = context,
+            Method = method,
+            Url = page.Url,
+            Title = await TryGetInnerTextAsync(page.Locator("#description h1, #info-contents h2, #shorts-player h1")),
+            ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-container a")),
+            PlannedWatchDurationMs = planned,
+            ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
+            StartedAt = start,
+            IsShort = true
+        };
+
+        LogVideoWatch(result);
+        return result;
+    }
+
+    private void LogVideoWatch(VideoWatchResult result)
+    {
+        _logger?.LogInformation(
+            "YouTube watch context={Context} method={Method} url={Url} title={Title} channel={Channel} planned_ms={Planned} actual_ms={Actual} started={Started:o} short={IsShort} identity={Identity}.",
+            result.Context,
+            result.Method,
+            result.Url ?? "unknown",
+            string.IsNullOrWhiteSpace(result.Title) ? "(unknown)" : result.Title,
+            string.IsNullOrWhiteSpace(result.ChannelName) ? "(unknown)" : result.ChannelName,
+            result.PlannedWatchDurationMs,
+            result.ActualWatchDurationMs,
+            result.StartedAt,
+            result.IsShort,
+            _identityProfile?.IdentityKey ?? "default");
+    }
+
+    private async Task MaybeChainRecommendedVideosAsync(YouTubeWarmupSettings warmup, VideoWatchResult initialResult)
+    {
+        double probability = Math.Clamp(warmup.RecommendationChainProbability, 0, 1);
+        if (_random.NextDouble() > probability)
+        {
+            return;
+        }
+
+        _logger?.LogInformation(
+            "Evaluating recommendation chain after video {Url} (context={Context}).",
+            initialResult.Url ?? "unknown",
+            initialResult.Context);
+
+        int minChain = Math.Max(1, warmup.MinRecommendationChainLength);
+        int maxChain = Math.Max(minChain, warmup.MaxRecommendationChainLength);
+        int chainCount = _random.Next(minChain, maxChain + 1);
+
+        var page = await EnsurePageAsync();
+        for (int i = 0; i < chainCount; i++)
+        {
+            string previousUrl = page.Url;
+            bool useAutoplay = i == 0 && _random.NextDouble() < Math.Clamp(warmup.AutoplayFollowProbability, 0, 1);
+            bool navigated;
+            string method;
+
+            if (useAutoplay)
+            {
+                navigated = await TriggerAutoplayAsync(page);
+                method = "Autoplay";
+            }
+            else
+            {
+                navigated = await OpenRecommendedSidebarVideoAsync(page);
+                method = "ManualSidebar";
+            }
+
+            if (!navigated)
+            {
+                break;
+            }
+
+            try
+            {
+                await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+            }
+            catch (TimeoutException)
+            {
+                _logger?.LogWarning("Timed out waiting for recommended video to load.");
+            }
+
+            await Task.Delay(_random.Next(1000, 2200));
+
+            if (string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger?.LogDebug("Recommended navigation did not change URL. Ending chain early.");
+                break;
+            }
+
+            var result = await WatchVideoAsync(warmup, "Recommendation", method);
+            if (result == null)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task<bool> TriggerAutoplayAsync(IPage page)
+    {
+        try
+        {
+            await Task.Delay(_random.Next(1800, 3200));
+            if (_random.NextDouble() < 0.6)
+            {
+                await page.Keyboard.PressAsync("Shift+N");
+            }
+            else
+            {
+                var nextButton = page.Locator("a[aria-label*='Next'], button[aria-label*='Next']");
+                if (await nextButton.CountAsync() > 0)
+                {
+                    await _mouseHelper!.MoveAndClickAsync(nextButton.First);
+                }
+                else
+                {
+                    await page.Keyboard.PressAsync("Shift+N");
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to trigger autoplay navigation.");
+            return false;
+        }
+    }
+
+    private async Task<bool> OpenRecommendedSidebarVideoAsync(IPage page)
+    {
+        try
+        {
+            var recTiles = page.Locator("ytd-compact-video-renderer a#thumbnail, ytd-watch-next-secondary-results-renderer a#thumbnail");
+            int count = await recTiles.CountAsync();
+            if (count == 0)
+            {
+                return false;
+            }
+
+            int selectionCount = Math.Min(count, 6);
+            int index = _random.Next(0, selectionCount);
+            var target = recTiles.Nth(index);
+            await ScrollHelper.ScrollToElementAsync(page, target);
+            await _mouseHelper!.MoveAndClickAsync(target);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to open recommended video from sidebar.");
+            return false;
+        }
+    }
+
+    private int PlanWatchDuration(int min, int max)
+    {
+        if (min >= max)
+        {
+            return min;
+        }
+
+        double roll = _random.NextDouble();
+        int range = max - min;
+        int shortUpper = min + (int)(range * 0.2);
+        int mediumUpper = min + (int)(range * 0.7);
+
+        if (roll < 0.15)
+        {
+            return _random.Next(min, shortUpper + 1);
+        }
+
+        if (roll < 0.85)
+        {
+            return _random.Next(shortUpper, mediumUpper + 1);
+        }
+
+        return _random.Next(Math.Max(mediumUpper, min), max + 1);
+    }
+
+    private int ApplyWatchDurationJitter(int planned, int min, int max)
+    {
+        double jitter = 0.9 + (_random.NextDouble() * 0.3); // 0.9x - 1.2x
+        int adjusted = (int)(planned * jitter);
+        return Math.Clamp(adjusted, min, max);
+    }
+
+    private async Task<string> TryGetInnerTextAsync(ILocator locator)
+    {
+        try
+        {
+            if (await locator.CountAsync() == 0)
+            {
+                return string.Empty;
+            }
+
+            string? text = await locator.First.InnerTextAsync();
+            return text?.Trim() ?? string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
         }
     }
 
@@ -405,37 +762,158 @@ internal class YouTubeWarmupService
 
     private async Task<string> PickKeywordAsync(string? keywordDirectory)
     {
-        if (string.IsNullOrWhiteSpace(keywordDirectory) || !Directory.Exists(keywordDirectory))
+        if (_identityKeywords != null && _identityKeywords.Count > 0)
         {
-            return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+            return _identityKeywords[_random.Next(_identityKeywords.Count)];
         }
+
+        if (!string.IsNullOrWhiteSpace(keywordDirectory) && Directory.Exists(keywordDirectory))
+        {
+            try
+            {
+                var files = Directory.GetFiles(keywordDirectory, "*.txt");
+                if (files.Length > 0)
+                {
+                    var file = files[_random.Next(files.Length)];
+                    var keywords = (await File.ReadAllLinesAsync(file))
+                        .Select(line => line.Trim())
+                        .Where(line => !string.IsNullOrWhiteSpace(line))
+                        .ToArray();
+
+                    if (keywords.Length > 0)
+                    {
+                        return keywords[_random.Next(keywords.Length)];
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Falling back to default YouTube keywords.");
+            }
+        }
+
+        return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+    }
+
+    private async Task EnsureIdentityKeywordsAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, string? profileKey)
+    {
+        if (_identityKeywords != null && _identityKeywords.Count > 0)
+        {
+            return;
+        }
+
+        string identityKey = string.IsNullOrWhiteSpace(profileKey) ? "default" : profileKey;
+        string baseDirectory = string.IsNullOrWhiteSpace(warmup.IdentityCacheDirectory)
+            ? Path.Combine(AppContext.BaseDirectory, "youtube-identities")
+            : Path.GetFullPath(warmup.IdentityCacheDirectory);
+
+        Directory.CreateDirectory(baseDirectory);
+        string fileName = SanitizeFileName(identityKey) + ".json";
+        string identityPath = Path.Combine(baseDirectory, fileName);
+
+        if (File.Exists(identityPath))
+        {
+            try
+            {
+                var existing = JsonSerializer.Deserialize<IdentityProfile>(await File.ReadAllTextAsync(identityPath));
+                if (existing != null && existing.Keywords.Count > 0)
+                {
+                    _identityProfile = existing;
+                    _identityKeywords = existing.Keywords;
+                    _logger?.LogInformation(
+                        "Loaded YouTube identity {Identity} with {KeywordCount} keywords from {Path}.",
+                        existing.IdentityKey,
+                        existing.Keywords.Count,
+                        identityPath);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to read YouTube identity file {Path}. Rebuilding.", identityPath);
+            }
+        }
+
+        var profile = await BuildIdentityProfileAsync(identityKey, keywordDirectory, warmup);
+        _identityProfile = profile;
+        _identityKeywords = profile.Keywords;
 
         try
         {
-            var files = Directory.GetFiles(keywordDirectory, "*.txt");
-            if (files.Length == 0)
-            {
-                return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
-            }
-
-            var file = files[_random.Next(files.Length)];
-            var keywords = (await File.ReadAllLinesAsync(file))
-                .Select(line => line.Trim())
-                .Where(line => !string.IsNullOrWhiteSpace(line))
-                .ToArray();
-
-            if (keywords.Length == 0)
-            {
-                return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
-            }
-
-            return keywords[_random.Next(keywords.Length)];
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            await File.WriteAllTextAsync(identityPath, JsonSerializer.Serialize(profile, options));
+            _logger?.LogInformation(
+                "Created YouTube identity {Identity} with {KeywordCount} keywords (sources={Sources}).",
+                profile.IdentityKey,
+                profile.Keywords.Count,
+                profile.SourceFiles.Count == 0 ? "fallback" : string.Join(",", profile.SourceFiles));
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Falling back to default YouTube keywords.");
-            return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+            _logger?.LogWarning(ex, "Failed to persist YouTube identity profile to {Path}.", identityPath);
         }
+    }
+
+    private async Task<IdentityProfile> BuildIdentityProfileAsync(string identityKey, string? keywordDirectory, YouTubeWarmupSettings warmup)
+    {
+        var profile = new IdentityProfile
+        {
+            IdentityKey = identityKey,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        if (!string.IsNullOrWhiteSpace(keywordDirectory) && Directory.Exists(keywordDirectory))
+        {
+            try
+            {
+                var files = Directory.GetFiles(keywordDirectory, "*.txt");
+                if (files.Length > 0)
+                {
+                    int selectionCount = Math.Clamp(warmup.IdentityKeywordFileCount, 1, files.Length);
+                    var selected = files.OrderBy(_ => _random.NextDouble()).Take(selectionCount).ToArray();
+
+                    foreach (var file in selected)
+                    {
+                        var keywords = (await File.ReadAllLinesAsync(file))
+                            .Select(line => line.Trim())
+                            .Where(line => !string.IsNullOrWhiteSpace(line))
+                            .ToArray();
+
+                        if (keywords.Length > 0)
+                        {
+                            profile.Keywords.AddRange(keywords);
+                            profile.SourceFiles.Add(Path.GetFileName(file));
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to build identity keywords from directory {Directory}.", keywordDirectory);
+            }
+        }
+
+        if (profile.Keywords.Count == 0)
+        {
+            profile.Keywords.AddRange(FallbackKeywords);
+        }
+        else
+        {
+            profile.Keywords = profile.Keywords
+                .Where(keyword => !string.IsNullOrWhiteSpace(keyword))
+                .Select(keyword => keyword.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        return profile;
+    }
+
+    private static string SanitizeFileName(string identityKey)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitized = new string(identityKey.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
+        return string.IsNullOrWhiteSpace(sanitized) ? "identity" : sanitized;
     }
 
     private async Task PauseBetweenActionsAsync(YouTubeWarmupSettings warmup)

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -47,6 +47,12 @@ internal class YouTubeWarmupService
         "gaming highlights"
     };
 
+    private static readonly string[] FreshLandingPhrases =
+    {
+        "thử tìm kiếm để bắt đầu",
+        "try searching to get started"
+    };
+
     private sealed class YouTubeIdentityDocument
     {
         public IdentityProfileInfo Profile { get; set; } = new();
@@ -347,6 +353,29 @@ internal class YouTubeWarmupService
 
     private async Task PerformInteractionAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
     {
+        await EnsureOnYouTubeAsync(warmup);
+        var page = await EnsurePageAsync();
+        bool freshLanding = await IsFreshLandingExperienceAsync(page);
+        if (freshLanding)
+        {
+            _logger?.LogInformation("Detected fresh YouTube landing page; prioritizing search and Shorts menu interactions.");
+
+            if (_random.NextDouble() < 0.7)
+            {
+                await SearchAndWatchAsync(keywordDirectory, warmup);
+            }
+            else
+            {
+                bool opened = await OpenShortsAsync(warmup, preferGuideMenu: true);
+                if (!opened)
+                {
+                    await SearchAndWatchAsync(keywordDirectory, warmup);
+                }
+            }
+
+            return;
+        }
+
         double normalizedSearchWeight = Math.Clamp(warmup.SearchWeight, 0, 1);
         double normalizedShortsWeight = Math.Clamp(warmup.ShortsWeight, 0, 1 - normalizedSearchWeight);
         double homeWeight = 1 - normalizedSearchWeight - normalizedShortsWeight;
@@ -424,6 +453,41 @@ internal class YouTubeWarmupService
                 // ignore parse failures
             }
         }
+    }
+
+    private async Task<bool> IsFreshLandingExperienceAsync(IPage page)
+    {
+        ILocator wrapper = page.Locator("#content-wrapper");
+        if (!await wrapper.IsVisibleAsync(new LocatorIsVisibleOptions { Timeout = 1000 }))
+        {
+            return false;
+        }
+
+        string? text;
+        try
+        {
+            text = (await wrapper.InnerTextAsync(new LocatorInnerTextOptions { Timeout = 1000 }))?.Trim();
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        string normalized = text.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        foreach (string phrase in FreshLandingPhrases)
+        {
+            if (normalized.Contains(phrase, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task SearchAndWatchAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
@@ -533,24 +597,42 @@ internal class YouTubeWarmupService
         }
     }
 
-    private async Task<bool> OpenShortsAsync(YouTubeWarmupSettings warmup)
+    private async Task<bool> OpenShortsAsync(YouTubeWarmupSettings warmup, bool preferGuideMenu = false)
     {
         var page = await EnsurePageAsync();
         await EnsureOnYouTubeAsync(warmup);
 
-        var shortsLink = page.Locator("ytd-mini-guide-entry-renderer a[href*='shorts'], a[title='Shorts']");
-        if (!await shortsLink.IsVisibleAsync())
+        bool guideOpened = false;
+        if (preferGuideMenu)
         {
-            var menuButton = page.Locator("button#guide-button, #guide-button");
-            if (await menuButton.CountAsync() > 0 && await menuButton.IsVisibleAsync())
-            {
-                await _mouseHelper!.MoveAndClickAsync(menuButton);
-                await Task.Delay(_random.Next(600, 1200));
-            }
+            guideOpened = await TryEnsureGuideMenuVisibleAsync(page);
         }
 
-        if (!await shortsLink.IsVisibleAsync())
+        var shortsLink = await TryFindShortsLinkAsync(page);
+        if (shortsLink == null || !await shortsLink.IsVisibleAsync())
         {
+            if (!guideOpened)
+            {
+                guideOpened = await TryEnsureGuideMenuVisibleAsync(page);
+            }
+
+            shortsLink = await TryFindShortsLinkAsync(page);
+        }
+
+        if (shortsLink == null || !await shortsLink.IsVisibleAsync())
+        {
+            if (_random.NextDouble() < 0.15)
+            {
+                string baseDomain = GetBaseYouTubeDomain();
+                await page.GotoAsync($"{baseDomain.TrimEnd('/')}/shorts", new PageGotoOptions
+                {
+                    Timeout = 45000,
+                    WaitUntil = WaitUntilState.DOMContentLoaded
+                });
+                await Task.Delay(_random.Next(800, 1500));
+                return await WatchShortsSequenceAsync(warmup);
+            }
+
             return false;
         }
 
@@ -569,7 +651,7 @@ internal class YouTubeWarmupService
         if (count == 0)
         {
             _logger?.LogWarning("No shorts available after navigating to Shorts page.");
-            return true;
+            return false;
         }
 
         int index = _random.Next(0, count);
@@ -805,8 +887,12 @@ internal class YouTubeWarmupService
         double detailRoll = _random.NextDouble();
         if (detailRoll < 0.25)
         {
-            var showMore = page.Locator("#expand, tp-yt-paper-button#expand, #more");
-            if (await showMore.CountAsync() > 0 && await showMore.IsVisibleAsync())
+            var showMore = await TryGetFirstVisibleLocatorAsync(
+                page,
+                "tp-yt-paper-button#expand",
+                "ytd-text-inline-expander tp-yt-paper-button#expand",
+                "ytd-expander tp-yt-paper-button#more");
+            if (showMore != null)
             {
                 if (_mouseHelper != null)
                 {
@@ -814,14 +900,17 @@ internal class YouTubeWarmupService
                 }
                 else
                 {
-                    await showMore.First.ClickAsync();
+                    await showMore.ClickAsync();
                 }
             }
         }
         else if (detailRoll < 0.35)
         {
-            var collapse = page.Locator("#collapse, tp-yt-paper-button#collapse");
-            if (await collapse.CountAsync() > 0 && await collapse.IsVisibleAsync())
+            var collapse = await TryGetFirstVisibleLocatorAsync(
+                page,
+                "tp-yt-paper-button#collapse",
+                "ytd-expander tp-yt-paper-button#collapse");
+            if (collapse != null)
             {
                 if (_mouseHelper != null)
                 {
@@ -829,7 +918,7 @@ internal class YouTubeWarmupService
                 }
                 else
                 {
-                    await collapse.First.ClickAsync();
+                    await collapse.ClickAsync();
                 }
             }
         }
@@ -1871,6 +1960,88 @@ internal class YouTubeWarmupService
         {
             _identityDocument.Profile.Domain = domain;
         }
+    }
+
+    private async Task<bool> TryEnsureGuideMenuVisibleAsync(IPage page)
+    {
+        var miniGuide = page.Locator("#items ytd-mini-guide-entry-renderer");
+        if (await miniGuide.CountAsync() > 0)
+        {
+            var firstItem = miniGuide.First;
+            if (await firstItem.IsVisibleAsync())
+            {
+                return false;
+            }
+        }
+
+        var menuButton = page.Locator("ytd-masthead button#guide-button").First;
+        if (!await menuButton.IsVisibleAsync())
+        {
+            return false;
+        }
+
+        if (_mouseHelper != null)
+        {
+            await _mouseHelper.MoveAndClickAsync(menuButton);
+        }
+        else
+        {
+            await menuButton.ClickAsync();
+        }
+
+        await Task.Delay(_random.Next(600, 1200));
+        return true;
+    }
+
+    private async Task<ILocator?> TryGetFirstVisibleLocatorAsync(IPage page, params string[] selectors)
+    {
+        foreach (string selector in selectors)
+        {
+            var locator = page.Locator(selector);
+            int count;
+            try
+            {
+                count = await locator.CountAsync();
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (count == 0)
+            {
+                continue;
+            }
+
+            var candidate = locator.First;
+            if (await candidate.IsVisibleAsync())
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private Task<ILocator?> TryFindShortsLinkAsync(IPage page)
+    {
+        return TryGetFirstVisibleLocatorAsync(
+            page,
+            "#items ytd-mini-guide-entry-renderer:nth-child(2) a",
+            "ytd-mini-guide-entry-renderer a[href*='shorts']",
+            "a[title='Shorts']",
+            "a[href='/shorts']");
+    }
+
+    private string GetBaseYouTubeDomain()
+    {
+        string? domain = _identityDocument?.Profile?.Domain;
+        if (!string.IsNullOrWhiteSpace(domain) && Uri.TryCreate(domain, UriKind.Absolute, out var uri))
+        {
+            return $"{uri.Scheme}://{uri.Host}";
+        }
+
+        return "https://www.youtube.com";
     }
 
     private async Task PauseBetweenActionsAsync(YouTubeWarmupSettings warmup)

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -508,6 +508,7 @@ internal class YouTubeWarmupService
         await Task.Delay(_random.Next(400, 1200));
 
         double decision = _random.NextDouble();
+        string previousUrl = page.Url;
         if (decision < 0.4)
         {
             var searchButton = page.Locator("button#search-icon-legacy");
@@ -530,8 +531,7 @@ internal class YouTubeWarmupService
             await input.PressAsync("Enter");
         }
 
-        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-        await Task.Delay(_random.Next(1200, 2500));
+        await WaitForNavigationAsync(page, previousUrl);
 
         var videoTiles = page.Locator("ytd-video-renderer a#thumbnail, ytd-grid-video-renderer a#thumbnail");
         if (await videoTiles.CountAsync() == 0)
@@ -544,10 +544,11 @@ internal class YouTubeWarmupService
         var target = videoTiles.Nth(index);
         _logger?.LogInformation("Opening YouTube search result #{Index}.", index + 1);
         await ScrollHelper.ScrollToElementAsync(page, target);
+        string beforeClickUrl = page.Url;
         await _mouseHelper!.MoveAndClickAsync(target);
 
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        var result = await WatchVideoAsync(
+        await WaitForNavigationAsync(page, beforeClickUrl);
+        var result = await WatchCurrentEntryAsync(
             warmup,
             context: "Search",
             method: "SearchResult",
@@ -580,9 +581,11 @@ internal class YouTubeWarmupService
         var target = richItems.Nth(index);
         _logger?.LogInformation("Opening YouTube home recommendation #{Index} of {Total}.", index + 1, count);
         await ScrollHelper.ScrollToElementAsync(page, target);
+        string beforeClickUrl = page.Url;
         await _mouseHelper!.MoveAndClickAsync(target);
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        var result = await WatchVideoAsync(
+        await WaitForNavigationAsync(page, beforeClickUrl);
+
+        var result = await WatchCurrentEntryAsync(
             warmup,
             context: "RecommendationHome",
             method: "HomeRecommendation",
@@ -657,8 +660,9 @@ internal class YouTubeWarmupService
         int index = _random.Next(0, count);
         var target = shortsTiles.Nth(index);
         _logger?.LogInformation("Opening YouTube short #{Index} of {Total}.", index + 1, count);
+        string beforeClickUrl = page.Url;
         await _mouseHelper!.MoveAndClickAsync(target);
-        await Task.Delay(_random.Next(800, 1500));
+        await WaitForNavigationAsync(page, beforeClickUrl);
 
         int minSequence = Math.Max(1, warmup.MinShortSequenceLength);
         int maxSequence = Math.Max(minSequence, warmup.MaxShortSequenceLength);
@@ -705,10 +709,11 @@ internal class YouTubeWarmupService
         var page = await EnsurePageAsync();
         try
         {
+            string previousUrl = page.Url;
             if (_random.NextDouble() < 0.55)
             {
                 await page.Keyboard.PressAsync("ArrowDown");
-                await Task.Delay(_random.Next(600, 1000));
+                await WaitForNavigationAsync(page, previousUrl);
                 return true;
             }
 
@@ -716,7 +721,7 @@ internal class YouTubeWarmupService
             if (await nextButton.CountAsync() > 0 && await nextButton.First.IsEnabledAsync())
             {
                 await _mouseHelper!.MoveAndClickAsync(nextButton.First);
-                await Task.Delay(_random.Next(600, 1000));
+                await WaitForNavigationAsync(page, previousUrl);
                 return true;
             }
         }
@@ -842,7 +847,7 @@ internal class YouTubeWarmupService
         return finalPercent;
     }
 
-    private async Task<VideoWatchResult?> WatchVideoAsync(
+    private async Task<VideoWatchResult?> WatchCurrentEntryAsync(
         YouTubeWarmupSettings warmup,
         string context,
         string method,
@@ -853,15 +858,51 @@ internal class YouTubeWarmupService
         VideoWatchResult? parent)
     {
         var page = await EnsurePageAsync();
+        var kind = YouTubeUrlHelper.GetVideoKind(page.Url);
+
+        return kind == YouTubeUrlHelper.YouTubeVideoKind.Short
+            ? await WatchShortAsync(
+                warmup,
+                context,
+                method,
+                contextDetail,
+                entryPoint,
+                position,
+                parent)
+            : await WatchVideoAsync(
+                warmup,
+                context,
+                method,
+                contextDetail,
+                entryPoint,
+                keyword,
+                position,
+                parent,
+                kind);
+    }
+
+    private async Task<VideoWatchResult?> WatchVideoAsync(
+        YouTubeWarmupSettings warmup,
+        string context,
+        string method,
+        string contextDetail,
+        string entryPoint,
+        string? keyword,
+        int? position,
+        VideoWatchResult? parent,
+        YouTubeUrlHelper.YouTubeVideoKind detectedKind)
+    {
+        var page = await EnsurePageAsync();
         try
         {
-            await page.WaitForSelectorAsync("ytd-player video", new PageWaitForSelectorOptions { Timeout = 20000 });
+            await WaitForStandardPlayerAsync(page);
         }
         catch
         {
             _logger?.LogWarning("Video element did not appear for context {Context}.", context);
         }
 
+        await FocusPlayerAsync(page, detectedKind);
         await MaybeSkipAdsAsync(page);
 
         int? volumePercent = await MaybeAdjustVolumeAsync(page);
@@ -963,6 +1004,8 @@ internal class YouTubeWarmupService
         VideoWatchResult? parent)
     {
         var page = await EnsurePageAsync();
+        await WaitForShortPlayerAsync(page);
+        await FocusPlayerAsync(page, YouTubeUrlHelper.YouTubeVideoKind.Short);
         await MaybeSkipAdsAsync(page);
 
         int? volumePercent = await MaybeAdjustVolumeAsync(page);
@@ -1008,6 +1051,104 @@ internal class YouTubeWarmupService
         return result;
     }
 
+    private async Task WaitForNavigationAsync(IPage page, string previousUrl)
+    {
+        try
+        {
+            for (int attempt = 0; attempt < 40; attempt++)
+            {
+                if (!string.Equals(page.Url, previousUrl, StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+
+                await Task.Delay(250);
+            }
+
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+            await Task.Delay(_random.Next(900, 1800));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Navigation wait encountered an issue.");
+        }
+    }
+
+    private static async Task WaitForStandardPlayerAsync(IPage page)
+    {
+        try
+        {
+            await page.WaitForSelectorAsync(
+                "video.html5-main-video, ytd-player video",
+                new PageWaitForSelectorOptions { Timeout = 20000 });
+        }
+        catch
+        {
+            // ignore and let caller handle missing player
+        }
+    }
+
+    private static async Task WaitForShortPlayerAsync(IPage page)
+    {
+        try
+        {
+            await page.WaitForSelectorAsync(
+                "#shorts-player video, ytd-reel-video-renderer video, ytd-shorts-player-renderer video",
+                new PageWaitForSelectorOptions { Timeout = 20000 });
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    private async Task FocusPlayerAsync(IPage page, YouTubeUrlHelper.YouTubeVideoKind kind)
+    {
+        try
+        {
+            string[] selectors = kind == YouTubeUrlHelper.YouTubeVideoKind.Short
+                ? new[]
+                {
+                    "#shorts-player video",
+                    "#shorts-player",
+                    "ytd-reel-video-renderer video"
+                }
+                : new[]
+                {
+                    "video.html5-main-video",
+                    "ytd-player video",
+                    "#movie_player"
+                };
+
+            foreach (string selector in selectors)
+            {
+                var locator = page.Locator(selector);
+                if (await locator.CountAsync() == 0)
+                {
+                    continue;
+                }
+
+                var element = locator.First;
+                if (!await element.IsVisibleAsync())
+                {
+                    continue;
+                }
+
+                await element.FocusAsync();
+                if (_mouseHelper != null)
+                {
+                    await _mouseHelper.MoveToAsync(element, steps: 12, addJitter: true);
+                }
+
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to focus YouTube player.");
+        }
+    }
+
     private async Task MaybeChainRecommendedVideosAsync(YouTubeWarmupSettings warmup, VideoWatchResult initialResult)
     {
         double probability = Math.Clamp(warmup.RecommendationChainProbability, 0, 1);
@@ -1029,6 +1170,35 @@ internal class YouTubeWarmupService
         var parent = initialResult;
         for (int i = 0; i < chainCount; i++)
         {
+            if (parent.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short)
+            {
+                if (!await TryNavigateShortContinuationAsync(page))
+                {
+                    break;
+                }
+
+                string beforeShortUrl = parent.Url ?? page.Url;
+                await WaitForNavigationAsync(page, beforeShortUrl);
+
+                var shortResult = await WatchCurrentEntryAsync(
+                    warmup,
+                    context: "RecommendationNext",
+                    method: "ShortsNavigation",
+                    contextDetail: $"ShortsChain#{i + 1}",
+                    entryPoint: parent.EntryPoint ?? "Recommendation",
+                    keyword: null,
+                    position: null,
+                    parent: parent);
+
+                if (shortResult == null)
+                {
+                    break;
+                }
+
+                parent = shortResult;
+                continue;
+            }
+
             string previousUrl = page.Url;
             bool useAutoplay = i == 0 && _random.NextDouble() < Math.Clamp(warmup.AutoplayFollowProbability, 0, 1);
             bool navigated;
@@ -1061,16 +1231,7 @@ internal class YouTubeWarmupService
                 break;
             }
 
-            try
-            {
-                await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-            }
-            catch (TimeoutException)
-            {
-                _logger?.LogWarning("Timed out waiting for recommended video to load.");
-            }
-
-            await Task.Delay(_random.Next(1000, 2200));
+            await WaitForNavigationAsync(page, previousUrl);
 
             if (string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
             {
@@ -1080,12 +1241,12 @@ internal class YouTubeWarmupService
 
             string recommendationContext = "RecommendationNext";
 
-            var result = await WatchVideoAsync(
+            var result = await WatchCurrentEntryAsync(
                 warmup,
                 context: recommendationContext,
                 method: method,
                 contextDetail: contextDetail,
-                entryPoint: parent.EntryPoint,
+                entryPoint: parent.EntryPoint ?? "Recommendation",
                 keyword: null,
                 position: position,
                 parent: parent);
@@ -1096,6 +1257,38 @@ internal class YouTubeWarmupService
 
             parent = result;
         }
+    }
+
+    private async Task<bool> TryNavigateShortContinuationAsync(IPage page)
+    {
+        try
+        {
+            string previousUrl = page.Url;
+            var downButton = page.Locator("#navigation-button-down button, #navigation-button-down tp-yt-paper-button, #navigation-button-down");
+            if (await downButton.CountAsync() > 0 && await downButton.First.IsVisibleAsync())
+            {
+                await _mouseHelper!.MoveAndClickAsync(downButton.First);
+            }
+            else
+            {
+                await page.Keyboard.PressAsync("ArrowDown");
+            }
+
+            for (int attempt = 0; attempt < 20; attempt++)
+            {
+                await Task.Delay(400);
+                if (!string.Equals(previousUrl, page.Url, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to navigate to next short during recommendation chain.");
+        }
+
+        return false;
     }
 
     private async Task<bool> TriggerAutoplayAsync(IPage page)
@@ -1133,6 +1326,45 @@ internal class YouTubeWarmupService
     {
         try
         {
+            bool adDetected = false;
+            int? detectedDurationMs = null;
+
+            for (int attempt = 0; attempt < 12; attempt++)
+            {
+                adDetected = await page.EvaluateAsync<bool>(
+                    "() => document.querySelector('.ad-showing, .ytp-ad-player-overlay, .ytp-ad-overlay-slot') !== null");
+                if (adDetected)
+                {
+                    string? durationText = await page.EvaluateAsync<string?>(
+                        "() => document.querySelector('.ytp-ad-duration-remaining .ytp-time-duration, .ytp-ad-duration-remaining')?.textContent ?? null");
+                    detectedDurationMs = ParseDurationToMilliseconds(durationText);
+                    break;
+                }
+
+                await Task.Delay(350);
+            }
+
+            if (!adDetected)
+            {
+                return;
+            }
+
+            int dwellMs;
+            if (detectedDurationMs.HasValue && detectedDurationMs.Value <= 15000)
+            {
+                dwellMs = _random.Next(5000, 8000);
+            }
+            else if (detectedDurationMs.HasValue && detectedDurationMs.Value <= 30000)
+            {
+                dwellMs = _random.Next(5000, 15000);
+            }
+            else
+            {
+                dwellMs = _random.Next(6000, 16000);
+            }
+
+            await Task.Delay(dwellMs);
+
             var skipSelectors = new[]
             {
                 "button.ytp-ad-skip-button", // primary skip button
@@ -1145,6 +1377,13 @@ internal class YouTubeWarmupService
 
             for (int attempt = 0; attempt < 6; attempt++)
             {
+                bool stillShowing = await page.EvaluateAsync<bool>(
+                    "() => document.querySelector('.ad-showing, .ytp-ad-player-overlay, .ytp-ad-overlay-slot') !== null");
+                if (!stillShowing)
+                {
+                    return;
+                }
+
                 foreach (string selector in skipSelectors)
                 {
                     var skipButton = page.Locator(selector);
@@ -1180,6 +1419,37 @@ internal class YouTubeWarmupService
         {
             _logger?.LogDebug(ex, "Failed while attempting to skip YouTube ads.");
         }
+    }
+
+    private static int? ParseDurationToMilliseconds(string? durationText)
+    {
+        if (string.IsNullOrWhiteSpace(durationText))
+        {
+            return null;
+        }
+
+        durationText = durationText.Trim();
+        var parts = durationText.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return null;
+        }
+
+        int seconds = 0;
+        int multiplier = 1;
+
+        for (int i = parts.Length - 1; i >= 0; i--)
+        {
+            if (!int.TryParse(parts[i], out int value))
+            {
+                return null;
+            }
+
+            seconds += value * multiplier;
+            multiplier *= 60;
+        }
+
+        return seconds * 1000;
     }
 
     private async Task<int?> OpenRecommendedSidebarVideoAsync(IPage page)

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -23,8 +23,19 @@ internal class YouTubeWarmupService
     private KeyboardHelper? _keyboardHelper;
     private bool _isFirstRun = true;
 
-    private IdentityProfile? _identityProfile;
-    private List<string>? _identityKeywords;
+    private YouTubeIdentityDocument? _identityDocument;
+    private readonly List<string> _identityKeywords = new();
+    private string _identityKey = "default";
+    private string? _identityDirectory;
+    private string? _sessionsDirectory;
+    private string? _identityPath;
+
+    private readonly List<SessionInteraction> _sessionInteractions = new();
+    private readonly Dictionary<string, int> _sessionSourceCounts = new(StringComparer.OrdinalIgnoreCase);
+    private string _sessionId = string.Empty;
+    private DateTimeOffset _sessionStart;
+    private long _sessionTotalWatchTimeMs;
+    private int _sessionBounceCount;
 
     private static readonly string[] FallbackKeywords =
     {
@@ -36,18 +47,104 @@ internal class YouTubeWarmupService
         "gaming highlights"
     };
 
-    private sealed class IdentityProfile
+    private sealed class YouTubeIdentityDocument
     {
-        public string IdentityKey { get; set; } = string.Empty;
-        public List<string> Keywords { get; set; } = new();
+        public IdentityProfileInfo Profile { get; set; } = new();
+        public KeywordSection Keywords { get; set; } = new();
+        public IdentityStats Stats { get; set; } = new();
         public List<string> SourceFiles { get; set; } = new();
+    }
+
+    private sealed class IdentityProfileInfo
+    {
+        public string ProfileId { get; set; } = string.Empty;
+        public string Persona { get; set; } = "Generalist";
+        public string Region { get; set; } = "Global";
+        public string Language { get; set; } = "en-US";
+        public string Domain { get; set; } = "https://www.youtube.com";
+        public string Timezone { get; set; } = TimeZoneInfo.Utc.Id;
         public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
+        public string[] Behaviors { get; set; } = Array.Empty<string>();
+    }
+
+    private sealed class KeywordSection
+    {
+        public List<string> SeedList { get; set; } = new();
+        public List<KeywordUsageRecord> UsedHistory { get; set; } = new();
+        public List<KeywordVideoRecord> KeywordHistory { get; set; } = new();
+    }
+
+    private sealed class KeywordUsageRecord
+    {
+        public string Keyword { get; set; } = string.Empty;
+        public int TimesUsed { get; set; }
+            = 0;
+        public DateTimeOffset? LastUsed { get; set; }
+            = null;
+    }
+
+    private sealed class KeywordVideoRecord
+    {
+        public string Keyword { get; set; } = string.Empty;
+        public string VideoUrl { get; set; } = string.Empty;
+        public int WatchedMs { get; set; }
+            = 0;
+        public DateTimeOffset WatchedAt { get; set; } = DateTimeOffset.UtcNow;
+    }
+
+    private sealed class IdentityStats
+    {
+        public int TotalSessions { get; set; }
+            = 0;
+        public int TotalVideosWatched { get; set; }
+            = 0;
+        public long TotalWatchTimeMs { get; set; }
+            = 0;
+        public double AvgWatchDurationMs { get; set; }
+            = 0;
+        public double BounceRate { get; set; }
+            = 0;
+        public double DeepSessionRate { get; set; }
+            = 0;
+        public int BounceVideos { get; set; }
+            = 0;
+        public int DeepSessions { get; set; }
+            = 0;
+        public DateTimeOffset? LastSessionTimestamp { get; set; }
+            = null;
+        public DateTimeOffset? LastWatchedAt { get; set; }
+            = null;
+        public SourceBreakdown SourceDistribution { get; set; } = new();
+        public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
+    }
+
+    private sealed class SourceBreakdown
+    {
+        public int SearchCount { get; set; }
+            = 0;
+        public int HomeCount { get; set; }
+            = 0;
+        public int ShortsCount { get; set; }
+            = 0;
+        public double SearchPercent { get; set; }
+            = 0;
+        public double HomePercent { get; set; }
+            = 0;
+        public double ShortsPercent { get; set; }
+            = 0;
     }
 
     private sealed class VideoWatchResult
     {
         public string Context { get; set; } = string.Empty;
+        public string ContextDetail { get; set; } = string.Empty;
+        public string EntryPoint { get; set; } = string.Empty;
         public string Method { get; set; } = string.Empty;
+        public int? ResultPosition { get; set; }
+            = null;
+        public string? Keyword { get; set; }
+            = null;
         public string? Url { get; set; }
             = string.Empty;
         public string? Title { get; set; }
@@ -62,6 +159,77 @@ internal class YouTubeWarmupService
             = DateTimeOffset.UtcNow;
         public bool IsShort { get; set; }
             = false;
+        public string? ParentVideoUrl { get; set; }
+            = null;
+        public string? ParentVideoTitle { get; set; }
+            = null;
+        public string? ParentContext { get; set; }
+            = null;
+    }
+
+    private sealed class SessionInteraction
+    {
+        public string Context { get; set; } = string.Empty;
+        public string ContextDetail { get; set; } = string.Empty;
+        public string EntryPoint { get; set; } = string.Empty;
+        public string Method { get; set; } = string.Empty;
+        public int? ResultPosition { get; set; }
+            = null;
+        public string? Keyword { get; set; }
+            = null;
+        public string? VideoUrl { get; set; }
+            = string.Empty;
+        public string? Title { get; set; }
+            = string.Empty;
+        public string? ChannelName { get; set; }
+            = string.Empty;
+        public int PlannedWatchMs { get; set; }
+            = 0;
+        public int ActualWatchMs { get; set; }
+            = 0;
+        public DateTimeOffset StartedAt { get; set; } = DateTimeOffset.UtcNow;
+        public bool IsShort { get; set; }
+            = false;
+        public string? ParentVideo { get; set; }
+            = null;
+        public string? ParentVideoTitle { get; set; }
+            = null;
+        public string? ParentContext { get; set; }
+            = null;
+    }
+
+    private sealed class SessionLog
+    {
+        public string SessionId { get; set; } = string.Empty;
+        public DateTimeOffset StartedAt { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset EndedAt { get; set; } = DateTimeOffset.UtcNow;
+        public List<SessionInteraction> Interactions { get; set; } = new();
+        public SessionSummary Summary { get; set; } = new();
+    }
+
+    private sealed class SessionSummary
+    {
+        public int VideosWatched { get; set; }
+            = 0;
+        public long TotalWatchTimeMs { get; set; }
+            = 0;
+        public double AverageWatchTimeMs { get; set; }
+            = 0;
+        public int BounceCount { get; set; }
+            = 0;
+        public bool DeepChain { get; set; }
+            = false;
+        public SessionSourceBreakdown Sources { get; set; } = new();
+    }
+
+    private sealed class SessionSourceBreakdown
+    {
+        public int Search { get; set; }
+            = 0;
+        public int Home { get; set; }
+            = 0;
+        public int Shorts { get; set; }
+            = 0;
     }
 
     public YouTubeWarmupService(IBrowserContext context, ILogger<YouTubeWarmupService>? logger = null)
@@ -103,46 +271,54 @@ internal class YouTubeWarmupService
             warmup.MinShortWatchMilliseconds = Math.Min(8000, warmup.MaxShortWatchMilliseconds);
         }
 
-        await EnsureIdentityKeywordsAsync(keywordDirectory, warmup, profileKey);
+        await EnsureIdentityAsync(keywordDirectory, warmup, profileKey);
+        BeginSession();
 
-        int completed = 0;
-        while (true)
+        try
         {
-            try
+            int completed = 0;
+            while (true)
             {
-                await EnsureOnYouTubeAsync(warmup);
-                await PerformInteractionAsync(keywordDirectory, warmup);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "YouTube interaction failed.");
-            }
+                try
+                {
+                    await EnsureOnYouTubeAsync(warmup);
+                    await PerformInteractionAsync(keywordDirectory, warmup);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "YouTube interaction failed.");
+                }
 
-            _isFirstRun = false;
-            completed++;
+                _isFirstRun = false;
+                completed++;
 
-            if (completed >= warmup.MaxInteractions)
-            {
-                _logger?.LogInformation("Reached max YouTube interactions ({Count}). Ending warmup.", completed);
-                break;
-            }
+                if (completed >= warmup.MaxInteractions)
+                {
+                    _logger?.LogInformation("Reached max YouTube interactions ({Count}). Ending warmup.", completed);
+                    break;
+                }
 
-            if (completed < warmup.MinInteractions)
-            {
-                _logger?.LogInformation("Completed {Count} YouTube interactions but minimum is {Minimum}. Continuing.", completed, warmup.MinInteractions);
+                if (completed < warmup.MinInteractions)
+                {
+                    _logger?.LogInformation("Completed {Count} YouTube interactions but minimum is {Minimum}. Continuing.", completed, warmup.MinInteractions);
+                    await PauseBetweenActionsAsync(warmup);
+                    continue;
+                }
+
+                double roll = _random.NextDouble();
+                if (roll >= warmup.ContinueProbability)
+                {
+                    _logger?.LogInformation("Stopping YouTube warmup after {Count} interactions (roll={Roll:0.00} threshold={Threshold:0.00}).", completed, roll, warmup.ContinueProbability);
+                    break;
+                }
+
+                _logger?.LogInformation("Continuing YouTube warmup after {Count} interactions (roll={Roll:0.00}).", completed, roll);
                 await PauseBetweenActionsAsync(warmup);
-                continue;
             }
-
-            double roll = _random.NextDouble();
-            if (roll >= warmup.ContinueProbability)
-            {
-                _logger?.LogInformation("Stopping YouTube warmup after {Count} interactions (roll={Roll:0.00} threshold={Threshold:0.00}).", completed, roll, warmup.ContinueProbability);
-                break;
-            }
-
-            _logger?.LogInformation("Continuing YouTube warmup after {Count} interactions (roll={Roll:0.00}).", completed, roll);
-            await PauseBetweenActionsAsync(warmup);
+        }
+        finally
+        {
+            await FinalizeSessionAsync();
         }
     }
 
@@ -203,6 +379,7 @@ internal class YouTubeWarmupService
         {
             string domain = ChooseDomain(warmup);
             _logger?.LogInformation("Navigating to YouTube domain {Domain} (current={Url}).", domain, url ?? "unknown");
+            SetActiveDomain(domain);
             await page.GotoAsync(domain, new PageGotoOptions
             {
                 Timeout = 60000,
@@ -210,6 +387,19 @@ internal class YouTubeWarmupService
             });
             await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             await Task.Delay(_random.Next(1000, 2500));
+        }
+        else if (!string.IsNullOrWhiteSpace(url))
+        {
+            try
+            {
+                var uri = new Uri(url);
+                string baseDomain = $"{uri.Scheme}://{uri.Host}";
+                SetActiveDomain(baseDomain);
+            }
+            catch
+            {
+                // ignore parse failures
+            }
         }
     }
 
@@ -219,9 +409,10 @@ internal class YouTubeWarmupService
         await EnsureOnYouTubeAsync(warmup);
 
         string keyword = await PickKeywordAsync(keywordDirectory);
+        RegisterKeywordUsage(keyword);
         _logger?.LogInformation(
             "YouTube identity {Identity} searching for keyword '{Keyword}'.",
-            _identityProfile?.IdentityKey ?? "default",
+            _identityKey,
             keyword);
 
         var input = await FocusSearchBoxAsync();
@@ -269,7 +460,15 @@ internal class YouTubeWarmupService
         await _mouseHelper!.MoveAndClickAsync(target);
 
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        var result = await WatchVideoAsync(warmup, "Search", "SearchResult");
+        var result = await WatchVideoAsync(
+            warmup,
+            context: "Search",
+            method: "SearchResult",
+            contextDetail: $"SearchResult#{index + 1}",
+            entryPoint: "Search",
+            keyword: keyword,
+            position: index + 1,
+            parent: null);
         if (result != null)
         {
             await MaybeChainRecommendedVideosAsync(warmup, result);
@@ -296,7 +495,15 @@ internal class YouTubeWarmupService
         await ScrollHelper.ScrollToElementAsync(page, target);
         await _mouseHelper!.MoveAndClickAsync(target);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        var result = await WatchVideoAsync(warmup, "Home", "HomeRecommendation");
+        var result = await WatchVideoAsync(
+            warmup,
+            context: "Home",
+            method: "HomeRecommendation",
+            contextDetail: $"HomeRecommendation#{index + 1}",
+            entryPoint: "Home",
+            keyword: null,
+            position: index + 1,
+            parent: null);
         if (result != null)
         {
             await MaybeChainRecommendedVideosAsync(warmup, result);
@@ -352,13 +559,28 @@ internal class YouTubeWarmupService
         int maxSequence = Math.Max(minSequence, warmup.MaxShortSequenceLength);
         int sequenceCount = _random.Next(minSequence, maxSequence + 1);
 
+        VideoWatchResult? previous = null;
         for (int i = 0; i < sequenceCount; i++)
         {
-            var result = await WatchShortAsync(warmup, i == 0 ? "Shorts" : "ShortsContinuation", i == 0 ? "InitialShort" : "NextShort");
+            string context = i == 0 ? "Shorts" : "ShortsContinuation";
+            string method = i == 0 ? "InitialShort" : "NextShort";
+            string detail = $"Shorts#{i + 1}";
+            string entryPoint = previous?.EntryPoint ?? "Shorts";
+
+            var result = await WatchShortAsync(
+                warmup,
+                context,
+                method,
+                detail,
+                entryPoint,
+                position: i + 1,
+                parent: previous);
             if (result == null)
             {
                 break;
             }
+
+            previous = result;
 
             if (i < sequenceCount - 1)
             {
@@ -401,7 +623,15 @@ internal class YouTubeWarmupService
         return false;
     }
 
-    private async Task<VideoWatchResult?> WatchVideoAsync(YouTubeWarmupSettings warmup, string context, string method)
+    private async Task<VideoWatchResult?> WatchVideoAsync(
+        YouTubeWarmupSettings warmup,
+        string context,
+        string method,
+        string contextDetail,
+        string entryPoint,
+        string? keyword,
+        int? position,
+        VideoWatchResult? parent)
     {
         var page = await EnsurePageAsync();
         try
@@ -446,21 +676,35 @@ internal class YouTubeWarmupService
         var result = new VideoWatchResult
         {
             Context = context,
+            ContextDetail = contextDetail,
+            EntryPoint = string.IsNullOrWhiteSpace(entryPoint) ? context : entryPoint,
             Method = method,
+            ResultPosition = position,
+            Keyword = keyword,
             Url = page.Url,
             Title = await TryGetInnerTextAsync(page.Locator("h1 yt-formatted-string")),
             ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-name a")),
             PlannedWatchDurationMs = planned,
             ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
             StartedAt = start,
-            IsShort = false
+            IsShort = false,
+            ParentVideoUrl = parent?.Url,
+            ParentVideoTitle = parent?.Title,
+            ParentContext = parent?.ContextDetail ?? parent?.Context
         };
 
-        LogVideoWatch(result);
+        RecordVideoWatch(result);
         return result;
     }
 
-    private async Task<VideoWatchResult?> WatchShortAsync(YouTubeWarmupSettings warmup, string context, string method)
+    private async Task<VideoWatchResult?> WatchShortAsync(
+        YouTubeWarmupSettings warmup,
+        string context,
+        string method,
+        string contextDetail,
+        string entryPoint,
+        int? position,
+        VideoWatchResult? parent)
     {
         var page = await EnsurePageAsync();
         int planned = PlanWatchDuration(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
@@ -481,34 +725,24 @@ internal class YouTubeWarmupService
         var result = new VideoWatchResult
         {
             Context = context,
+            ContextDetail = contextDetail,
+            EntryPoint = string.IsNullOrWhiteSpace(entryPoint) ? context : entryPoint,
             Method = method,
+            ResultPosition = position,
             Url = page.Url,
             Title = await TryGetInnerTextAsync(page.Locator("#description h1, #info-contents h2, #shorts-player h1")),
             ChannelName = await TryGetInnerTextAsync(page.Locator("#channel-name a, #owner-container a")),
             PlannedWatchDurationMs = planned,
             ActualWatchDurationMs = (int)stopwatch.Elapsed.TotalMilliseconds,
             StartedAt = start,
-            IsShort = true
+            IsShort = true,
+            ParentVideoUrl = parent?.Url,
+            ParentVideoTitle = parent?.Title,
+            ParentContext = parent?.ContextDetail ?? parent?.Context
         };
 
-        LogVideoWatch(result);
+        RecordVideoWatch(result);
         return result;
-    }
-
-    private void LogVideoWatch(VideoWatchResult result)
-    {
-        _logger?.LogInformation(
-            "YouTube watch context={Context} method={Method} url={Url} title={Title} channel={Channel} planned_ms={Planned} actual_ms={Actual} started={Started:o} short={IsShort} identity={Identity}.",
-            result.Context,
-            result.Method,
-            result.Url ?? "unknown",
-            string.IsNullOrWhiteSpace(result.Title) ? "(unknown)" : result.Title,
-            string.IsNullOrWhiteSpace(result.ChannelName) ? "(unknown)" : result.ChannelName,
-            result.PlannedWatchDurationMs,
-            result.ActualWatchDurationMs,
-            result.StartedAt,
-            result.IsShort,
-            _identityProfile?.IdentityKey ?? "default");
     }
 
     private async Task MaybeChainRecommendedVideosAsync(YouTubeWarmupSettings warmup, VideoWatchResult initialResult)
@@ -529,22 +763,34 @@ internal class YouTubeWarmupService
         int chainCount = _random.Next(minChain, maxChain + 1);
 
         var page = await EnsurePageAsync();
+        var parent = initialResult;
         for (int i = 0; i < chainCount; i++)
         {
             string previousUrl = page.Url;
             bool useAutoplay = i == 0 && _random.NextDouble() < Math.Clamp(warmup.AutoplayFollowProbability, 0, 1);
             bool navigated;
             string method;
+            string contextDetail;
+            int? position = null;
 
             if (useAutoplay)
             {
                 navigated = await TriggerAutoplayAsync(page);
                 method = "Autoplay";
+                contextDetail = "AutoplayNext";
             }
             else
             {
-                navigated = await OpenRecommendedSidebarVideoAsync(page);
+                int? selection = await OpenRecommendedSidebarVideoAsync(page);
+                navigated = selection.HasValue;
                 method = "ManualSidebar";
+                if (!navigated)
+                {
+                    break;
+                }
+
+                position = selection!.Value + 1;
+                contextDetail = $"Sidebar#{position}";
             }
 
             if (!navigated)
@@ -569,11 +815,21 @@ internal class YouTubeWarmupService
                 break;
             }
 
-            var result = await WatchVideoAsync(warmup, "Recommendation", method);
+            var result = await WatchVideoAsync(
+                warmup,
+                context: "Recommendation",
+                method: method,
+                contextDetail: contextDetail,
+                entryPoint: parent.EntryPoint,
+                keyword: null,
+                position: position,
+                parent: parent);
             if (result == null)
             {
                 break;
             }
+
+            parent = result;
         }
     }
 
@@ -608,7 +864,7 @@ internal class YouTubeWarmupService
         }
     }
 
-    private async Task<bool> OpenRecommendedSidebarVideoAsync(IPage page)
+    private async Task<int?> OpenRecommendedSidebarVideoAsync(IPage page)
     {
         try
         {
@@ -616,7 +872,7 @@ internal class YouTubeWarmupService
             int count = await recTiles.CountAsync();
             if (count == 0)
             {
-                return false;
+                return null;
             }
 
             int selectionCount = Math.Min(count, 6);
@@ -624,12 +880,12 @@ internal class YouTubeWarmupService
             var target = recTiles.Nth(index);
             await ScrollHelper.ScrollToElementAsync(page, target);
             await _mouseHelper!.MoveAndClickAsync(target);
-            return true;
+            return index;
         }
         catch (Exception ex)
         {
             _logger?.LogDebug(ex, "Failed to open recommended video from sidebar.");
-            return false;
+            return null;
         }
     }
 
@@ -687,6 +943,7 @@ internal class YouTubeWarmupService
     {
         var page = await EnsurePageAsync();
         string domain = ChooseDomain(warmup);
+        SetActiveDomain(domain);
         if (!page.Url.StartsWith(domain, StringComparison.OrdinalIgnoreCase))
         {
             _logger?.LogInformation("Navigating to YouTube home domain {Domain}.", domain);
@@ -760,10 +1017,37 @@ internal class YouTubeWarmupService
         }
     }
 
+
     private async Task<string> PickKeywordAsync(string? keywordDirectory)
     {
-        if (_identityKeywords != null && _identityKeywords.Count > 0)
+        if (_identityKeywords.Count > 0)
         {
+            if (_identityDocument?.Keywords != null)
+            {
+                var usageLookup = (_identityDocument.Keywords.UsedHistory ?? new List<KeywordUsageRecord>())
+                    .GroupBy(record => record.Keyword, StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.OrderByDescending(r => r.LastUsed ?? DateTimeOffset.MinValue).First())
+                    .ToDictionary(record => record.Keyword, record => record, StringComparer.OrdinalIgnoreCase);
+
+                var ranked = _identityKeywords
+                    .Select(keyword =>
+                    {
+                        usageLookup.TryGetValue(keyword, out var record);
+                        int usage = record?.TimesUsed ?? 0;
+                        DateTimeOffset lastUsed = record?.LastUsed ?? DateTimeOffset.MinValue;
+                        return new { keyword, usage, lastUsed };
+                    })
+                    .OrderBy(item => item.usage)
+                    .ThenBy(item => item.lastUsed)
+                    .ThenBy(_ => _random.NextDouble())
+                    .FirstOrDefault();
+
+                if (ranked != null)
+                {
+                    return ranked.keyword;
+                }
+            }
+
             return _identityKeywords[_random.Next(_identityKeywords.Count)];
         }
 
@@ -795,72 +1079,181 @@ internal class YouTubeWarmupService
         return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
     }
 
-    private async Task EnsureIdentityKeywordsAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, string? profileKey)
+    private async Task EnsureIdentityAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, string? profileKey)
     {
-        if (_identityKeywords != null && _identityKeywords.Count > 0)
+        if (_identityDocument != null && _identityKeywords.Count > 0)
         {
             return;
         }
 
-        string identityKey = string.IsNullOrWhiteSpace(profileKey) ? "default" : profileKey;
+        _identityKey = string.IsNullOrWhiteSpace(profileKey) ? "default" : profileKey;
         string baseDirectory = string.IsNullOrWhiteSpace(warmup.IdentityCacheDirectory)
             ? Path.Combine(AppContext.BaseDirectory, "youtube-identities")
             : Path.GetFullPath(warmup.IdentityCacheDirectory);
 
         Directory.CreateDirectory(baseDirectory);
-        string fileName = SanitizeFileName(identityKey) + ".json";
-        string identityPath = Path.Combine(baseDirectory, fileName);
+        string safeKey = SanitizeFileName(_identityKey);
+        _identityDirectory = Path.Combine(baseDirectory, safeKey);
+        Directory.CreateDirectory(_identityDirectory);
+        _sessionsDirectory = Path.Combine(_identityDirectory, "sessions");
+        Directory.CreateDirectory(_sessionsDirectory);
+        _identityPath = Path.Combine(_identityDirectory, "identity.json");
 
-        if (File.Exists(identityPath))
+        YouTubeIdentityDocument? document = null;
+        if (File.Exists(_identityPath))
         {
             try
             {
-                var existing = JsonSerializer.Deserialize<IdentityProfile>(await File.ReadAllTextAsync(identityPath));
-                if (existing != null && existing.Keywords.Count > 0)
-                {
-                    _identityProfile = existing;
-                    _identityKeywords = existing.Keywords;
-                    _logger?.LogInformation(
-                        "Loaded YouTube identity {Identity} with {KeywordCount} keywords from {Path}.",
-                        existing.IdentityKey,
-                        existing.Keywords.Count,
-                        identityPath);
-                    return;
-                }
+                document = JsonSerializer.Deserialize<YouTubeIdentityDocument>(await File.ReadAllTextAsync(_identityPath));
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "Failed to read YouTube identity file {Path}. Rebuilding.", identityPath);
+                _logger?.LogWarning(ex, "Failed to read YouTube identity document from {Path}. Rebuilding.", _identityPath);
             }
         }
 
-        var profile = await BuildIdentityProfileAsync(identityKey, keywordDirectory, warmup);
-        _identityProfile = profile;
-        _identityKeywords = profile.Keywords;
-
-        try
+        bool updated = false;
+        if (document == null)
         {
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            await File.WriteAllTextAsync(identityPath, JsonSerializer.Serialize(profile, options));
+            document = await CreateNewIdentityDocumentAsync(keywordDirectory, warmup);
+            updated = true;
             _logger?.LogInformation(
                 "Created YouTube identity {Identity} with {KeywordCount} keywords (sources={Sources}).",
-                profile.IdentityKey,
-                profile.Keywords.Count,
-                profile.SourceFiles.Count == 0 ? "fallback" : string.Join(",", profile.SourceFiles));
+                _identityKey,
+                document.Keywords.SeedList.Count,
+                document.SourceFiles.Count == 0 ? "fallback" : string.Join(",", document.SourceFiles));
         }
-        catch (Exception ex)
+
+        document.Profile ??= new IdentityProfileInfo();
+        if (!string.Equals(document.Profile.ProfileId, _identityKey, StringComparison.Ordinal))
         {
-            _logger?.LogWarning(ex, "Failed to persist YouTube identity profile to {Path}.", identityPath);
+            document.Profile.ProfileId = _identityKey;
+            updated = true;
+        }
+
+        if (string.IsNullOrWhiteSpace(document.Profile.Persona) && !string.IsNullOrWhiteSpace(warmup.Persona))
+        {
+            document.Profile.Persona = warmup.Persona;
+            updated = true;
+        }
+        if (string.IsNullOrWhiteSpace(document.Profile.Region) && !string.IsNullOrWhiteSpace(warmup.Region))
+        {
+            document.Profile.Region = warmup.Region;
+            updated = true;
+        }
+        if (string.IsNullOrWhiteSpace(document.Profile.Language) && !string.IsNullOrWhiteSpace(warmup.Language))
+        {
+            document.Profile.Language = warmup.Language;
+            updated = true;
+        }
+
+        if (string.IsNullOrWhiteSpace(document.Profile.Domain) && warmup.Domains?.Length > 0)
+        {
+            document.Profile.Domain = warmup.Domains[0];
+            updated = true;
+        }
+
+        string configuredTimezone = warmup.Timezone ?? TimeZoneInfo.Local.Id;
+        if (string.IsNullOrWhiteSpace(document.Profile.Timezone) || !string.Equals(document.Profile.Timezone, configuredTimezone, StringComparison.Ordinal))
+        {
+            document.Profile.Timezone = configuredTimezone;
+            updated = true;
+        }
+
+        if (warmup.Behaviors != null && warmup.Behaviors.Length > 0 && (document.Profile.Behaviors == null || document.Profile.Behaviors.Length == 0))
+        {
+            document.Profile.Behaviors = warmup.Behaviors;
+            updated = true;
+        }
+
+        document.Keywords ??= new KeywordSection();
+        document.Keywords.SeedList ??= new List<string>();
+        document.Keywords.UsedHistory ??= new List<KeywordUsageRecord>();
+        document.Keywords.KeywordHistory ??= new List<KeywordVideoRecord>();
+
+        if (document.Keywords.SeedList.Count == 0)
+        {
+            var (keywords, sources) = await BuildIdentityKeywordsAsync(keywordDirectory, warmup);
+            if (keywords.Count == 0)
+            {
+                keywords.AddRange(FallbackKeywords);
+            }
+
+            document.Keywords.SeedList = keywords;
+            document.SourceFiles = sources;
+            updated = true;
+        }
+
+        document.SourceFiles ??= new List<string>();
+        document.Stats ??= new IdentityStats();
+        document.Stats.SourceDistribution ??= new SourceBreakdown();
+
+        _identityDocument = document;
+        _identityKeywords.Clear();
+        _identityKeywords.AddRange(document.Keywords.SeedList);
+
+        if (_identityKeywords.Count == 0)
+        {
+            _identityKeywords.AddRange(FallbackKeywords);
+            document.Keywords.SeedList.AddRange(FallbackKeywords);
+            updated = true;
+        }
+
+        if (updated)
+        {
+            await SaveIdentityAsync();
         }
     }
 
-    private async Task<IdentityProfile> BuildIdentityProfileAsync(string identityKey, string? keywordDirectory, YouTubeWarmupSettings warmup)
+    private async Task<YouTubeIdentityDocument> CreateNewIdentityDocumentAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
     {
-        var profile = new IdentityProfile
+        var (keywords, sources) = await BuildIdentityKeywordsAsync(keywordDirectory, warmup);
+        if (keywords.Count == 0)
         {
-            IdentityKey = identityKey,
-            CreatedAt = DateTimeOffset.UtcNow
+            keywords.AddRange(FallbackKeywords);
+        }
+
+        var distinctKeywords = keywords
+            .Where(keyword => !string.IsNullOrWhiteSpace(keyword))
+            .Select(keyword => keyword.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var profile = new IdentityProfileInfo
+        {
+            ProfileId = _identityKey,
+            Persona = string.IsNullOrWhiteSpace(warmup.Persona) ? "Generalist" : warmup.Persona,
+            Region = string.IsNullOrWhiteSpace(warmup.Region) ? "Global" : warmup.Region,
+            Language = string.IsNullOrWhiteSpace(warmup.Language) ? "en-US" : warmup.Language,
+            Domain = warmup.Domains?.FirstOrDefault() ?? "https://www.youtube.com",
+            Timezone = warmup.Timezone ?? TimeZoneInfo.Local.Id,
+            CreatedAt = DateTimeOffset.UtcNow,
+            LastUpdated = DateTimeOffset.UtcNow,
+            Behaviors = warmup.Behaviors ?? Array.Empty<string>()
         };
+
+        return new YouTubeIdentityDocument
+        {
+            Profile = profile,
+            Keywords = new KeywordSection
+            {
+                SeedList = distinctKeywords,
+                UsedHistory = new List<KeywordUsageRecord>(),
+                KeywordHistory = new List<KeywordVideoRecord>()
+            },
+            Stats = new IdentityStats
+            {
+                LastUpdated = DateTimeOffset.UtcNow,
+                SourceDistribution = new SourceBreakdown()
+            },
+            SourceFiles = sources
+        };
+    }
+
+    private async Task<(List<string> Keywords, List<string> Sources)> BuildIdentityKeywordsAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    {
+        var keywords = new List<string>();
+        var sources = new List<string>();
 
         if (!string.IsNullOrWhiteSpace(keywordDirectory) && Directory.Exists(keywordDirectory))
         {
@@ -874,15 +1267,15 @@ internal class YouTubeWarmupService
 
                     foreach (var file in selected)
                     {
-                        var keywords = (await File.ReadAllLinesAsync(file))
+                        var fileKeywords = (await File.ReadAllLinesAsync(file))
                             .Select(line => line.Trim())
                             .Where(line => !string.IsNullOrWhiteSpace(line))
                             .ToArray();
 
-                        if (keywords.Length > 0)
+                        if (fileKeywords.Length > 0)
                         {
-                            profile.Keywords.AddRange(keywords);
-                            profile.SourceFiles.Add(Path.GetFileName(file));
+                            keywords.AddRange(fileKeywords);
+                            sources.Add(Path.GetFileName(file));
                         }
                     }
                 }
@@ -893,27 +1286,289 @@ internal class YouTubeWarmupService
             }
         }
 
-        if (profile.Keywords.Count == 0)
+        if (keywords.Count > 0)
         {
-            profile.Keywords.AddRange(FallbackKeywords);
-        }
-        else
-        {
-            profile.Keywords = profile.Keywords
+            keywords = keywords
                 .Where(keyword => !string.IsNullOrWhiteSpace(keyword))
                 .Select(keyword => keyword.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
 
-        return profile;
+        return (keywords, sources);
     }
 
-    private static string SanitizeFileName(string identityKey)
+    private void RegisterKeywordUsage(string keyword)
     {
-        var invalid = Path.GetInvalidFileNameChars();
-        var sanitized = new string(identityKey.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
-        return string.IsNullOrWhiteSpace(sanitized) ? "identity" : sanitized;
+        if (_identityDocument?.Keywords == null)
+        {
+            return;
+        }
+
+        var usage = _identityDocument.Keywords.UsedHistory
+            .FirstOrDefault(record => string.Equals(record.Keyword, keyword, StringComparison.OrdinalIgnoreCase));
+        if (usage == null)
+        {
+            usage = new KeywordUsageRecord
+            {
+                Keyword = keyword,
+                TimesUsed = 1,
+                LastUsed = DateTimeOffset.UtcNow
+            };
+            _identityDocument.Keywords.UsedHistory.Add(usage);
+        }
+        else
+        {
+            usage.TimesUsed++;
+            usage.LastUsed = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private void UpdateKeywordHistory(VideoWatchResult result)
+    {
+        if (_identityDocument?.Keywords == null || string.IsNullOrWhiteSpace(result.Keyword) || string.IsNullOrWhiteSpace(result.Url))
+        {
+            return;
+        }
+
+        var history = _identityDocument.Keywords.KeywordHistory;
+        var existing = history.FirstOrDefault(item =>
+            string.Equals(item.Keyword, result.Keyword, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(item.VideoUrl, result.Url, StringComparison.OrdinalIgnoreCase));
+
+        if (existing == null)
+        {
+            history.Add(new KeywordVideoRecord
+            {
+                Keyword = result.Keyword!,
+                VideoUrl = result.Url!,
+                WatchedMs = result.ActualWatchDurationMs,
+                WatchedAt = result.StartedAt
+            });
+        }
+        else
+        {
+            existing.WatchedMs = result.ActualWatchDurationMs;
+            existing.WatchedAt = result.StartedAt;
+        }
+
+        const int maxHistory = 200;
+        if (history.Count > maxHistory)
+        {
+            int remove = history.Count - maxHistory;
+            history.RemoveRange(0, Math.Min(remove, history.Count));
+        }
+    }
+
+    private void RecordVideoWatch(VideoWatchResult result)
+    {
+        string? rawTitle = string.IsNullOrWhiteSpace(result.Title) ? null : result.Title;
+        string? rawChannel = string.IsNullOrWhiteSpace(result.ChannelName) ? null : result.ChannelName;
+        string title = rawTitle ?? "(unknown)";
+        string channel = rawChannel ?? "(unknown)";
+
+        _logger?.LogInformation(
+            "YouTube watch identity={Identity} entry={Entry} context={Context} detail={Detail} method={Method} url={Url} title={Title} channel={Channel} planned_ms={Planned} actual_ms={Actual} started={Started:o} short={IsShort} parent={Parent}.",
+            _identityKey,
+            result.EntryPoint,
+            result.Context,
+            result.ContextDetail,
+            result.Method,
+            result.Url ?? "unknown",
+            title,
+            channel,
+            result.PlannedWatchDurationMs,
+            result.ActualWatchDurationMs,
+            result.StartedAt,
+            result.IsShort,
+            result.ParentVideoUrl ?? "none");
+
+        var interaction = new SessionInteraction
+        {
+            Context = result.Context,
+            ContextDetail = result.ContextDetail,
+            EntryPoint = string.IsNullOrWhiteSpace(result.EntryPoint) ? result.Context : result.EntryPoint,
+            Method = result.Method,
+            ResultPosition = result.ResultPosition,
+            Keyword = result.Keyword,
+            VideoUrl = result.Url,
+            Title = rawTitle,
+            ChannelName = rawChannel,
+            PlannedWatchMs = result.PlannedWatchDurationMs,
+            ActualWatchMs = result.ActualWatchDurationMs,
+            StartedAt = result.StartedAt,
+            IsShort = result.IsShort,
+            ParentVideo = result.ParentVideoUrl,
+            ParentVideoTitle = result.ParentVideoTitle,
+            ParentContext = result.ParentContext
+        };
+
+        _sessionInteractions.Add(interaction);
+        _sessionTotalWatchTimeMs += result.ActualWatchDurationMs;
+
+        if (IsBounce(result))
+        {
+            _sessionBounceCount++;
+        }
+
+        string entryPoint = interaction.EntryPoint;
+        if (!_sessionSourceCounts.ContainsKey(entryPoint))
+        {
+            _sessionSourceCounts[entryPoint] = 0;
+        }
+        _sessionSourceCounts[entryPoint]++;
+
+        UpdateKeywordHistory(result);
+    }
+
+    private void BeginSession()
+    {
+        _sessionInteractions.Clear();
+        _sessionSourceCounts.Clear();
+        _sessionTotalWatchTimeMs = 0;
+        _sessionBounceCount = 0;
+        _sessionStart = DateTimeOffset.UtcNow;
+        _sessionId = Guid.NewGuid().ToString("N");
+    }
+
+    private async Task FinalizeSessionAsync()
+    {
+        if (_identityDocument == null)
+        {
+            return;
+        }
+
+        DateTimeOffset endedAt = DateTimeOffset.UtcNow;
+        var summary = new SessionSummary
+        {
+            VideosWatched = _sessionInteractions.Count,
+            TotalWatchTimeMs = _sessionTotalWatchTimeMs,
+            AverageWatchTimeMs = _sessionInteractions.Count > 0
+                ? (double)_sessionTotalWatchTimeMs / _sessionInteractions.Count
+                : 0,
+            BounceCount = _sessionBounceCount,
+            DeepChain = _sessionInteractions.Count >= 3,
+            Sources = new SessionSourceBreakdown
+            {
+                Search = _sessionSourceCounts.TryGetValue("Search", out var search) ? search : 0,
+                Home = _sessionSourceCounts.TryGetValue("Home", out var home) ? home : 0,
+                Shorts = _sessionSourceCounts.TryGetValue("Shorts", out var shorts) ? shorts : 0
+            }
+        };
+
+        if (!string.IsNullOrEmpty(_sessionsDirectory))
+        {
+            try
+            {
+                Directory.CreateDirectory(_sessionsDirectory);
+                var sessionLog = new SessionLog
+                {
+                    SessionId = _sessionId,
+                    StartedAt = _sessionStart,
+                    EndedAt = endedAt,
+                    Interactions = new List<SessionInteraction>(_sessionInteractions),
+                    Summary = summary
+                };
+
+                string fileName = $"{_sessionStart:yyyy-MM-ddTHH-mm-ss}.json";
+                string sessionPath = Path.Combine(_sessionsDirectory, fileName);
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                await File.WriteAllTextAsync(sessionPath, JsonSerializer.Serialize(sessionLog, options));
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to persist YouTube warmup session log for identity {Identity}.", _identityKey);
+            }
+        }
+
+        _logger?.LogInformation(
+            "YouTube warmup session {SessionId} summary: videos={Videos} total_ms={Total} avg_ms={Average:0} bounce={Bounce} deep_chain={Deep} sources(search={Search}, home={Home}, shorts={Shorts}).",
+            _sessionId,
+            summary.VideosWatched,
+            summary.TotalWatchTimeMs,
+            summary.AverageWatchTimeMs,
+            summary.BounceCount,
+            summary.DeepChain,
+            summary.Sources.Search,
+            summary.Sources.Home,
+            summary.Sources.Shorts);
+
+        var stats = _identityDocument.Stats ??= new IdentityStats();
+        stats.TotalSessions++;
+        stats.TotalVideosWatched += summary.VideosWatched;
+        stats.TotalWatchTimeMs += summary.TotalWatchTimeMs;
+        stats.LastSessionTimestamp = endedAt;
+        if (summary.VideosWatched > 0)
+        {
+            stats.LastWatchedAt = endedAt;
+        }
+
+        stats.AvgWatchDurationMs = stats.TotalVideosWatched > 0
+            ? (double)stats.TotalWatchTimeMs / stats.TotalVideosWatched
+            : 0;
+
+        stats.BounceVideos += summary.BounceCount;
+        stats.BounceRate = stats.TotalVideosWatched > 0
+            ? (double)stats.BounceVideos / stats.TotalVideosWatched * 100
+            : 0;
+
+        if (summary.DeepChain)
+        {
+            stats.DeepSessions++;
+        }
+        stats.DeepSessionRate = stats.TotalSessions > 0
+            ? (double)stats.DeepSessions / stats.TotalSessions * 100
+            : 0;
+
+        stats.SourceDistribution ??= new SourceBreakdown();
+        stats.SourceDistribution.SearchCount += summary.Sources.Search;
+        stats.SourceDistribution.HomeCount += summary.Sources.Home;
+        stats.SourceDistribution.ShortsCount += summary.Sources.Shorts;
+
+        int totalVideos = stats.TotalVideosWatched;
+        if (totalVideos > 0)
+        {
+            stats.SourceDistribution.SearchPercent = (double)stats.SourceDistribution.SearchCount / totalVideos * 100;
+            stats.SourceDistribution.HomePercent = (double)stats.SourceDistribution.HomeCount / totalVideos * 100;
+            stats.SourceDistribution.ShortsPercent = (double)stats.SourceDistribution.ShortsCount / totalVideos * 100;
+        }
+
+        stats.LastUpdated = endedAt;
+        _identityDocument.Profile.LastUpdated = endedAt;
+
+        await SaveIdentityAsync();
+    }
+
+    private async Task SaveIdentityAsync()
+    {
+        if (_identityDocument == null || string.IsNullOrEmpty(_identityPath))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_identityPath)!);
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            await File.WriteAllTextAsync(_identityPath, JsonSerializer.Serialize(_identityDocument, options));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to persist YouTube identity document to {Path}.", _identityPath);
+        }
+    }
+
+    private void SetActiveDomain(string domain)
+    {
+        if (_identityDocument?.Profile == null)
+        {
+            return;
+        }
+
+        if (!string.Equals(_identityDocument.Profile.Domain, domain, StringComparison.OrdinalIgnoreCase))
+        {
+            _identityDocument.Profile.Domain = domain;
+        }
     }
 
     private async Task PauseBetweenActionsAsync(YouTubeWarmupSettings warmup)
@@ -922,6 +1577,24 @@ internal class YouTubeWarmupService
         int maxDelay = Math.Max(minDelay, warmup.MaxDelayBetweenActionsMs);
         int pause = _random.Next(minDelay, maxDelay + 1);
         await Task.Delay(pause);
+    }
+
+    private static bool IsBounce(VideoWatchResult result)
+    {
+        if (result.PlannedWatchDurationMs <= 0)
+        {
+            return false;
+        }
+
+        double ratio = (double)result.ActualWatchDurationMs / result.PlannedWatchDurationMs;
+        return ratio <= 0.2;
+    }
+
+    private static string SanitizeFileName(string identityKey)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitized = new string(identityKey.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
+        return string.IsNullOrWhiteSpace(sanitized) ? "identity" : sanitized;
     }
 
     private static bool IsOnYouTube(string? url)

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -52,6 +52,7 @@ internal class YouTubeWarmupService
         public IdentityProfileInfo Profile { get; set; } = new();
         public KeywordSection Keywords { get; set; } = new();
         public IdentityStats Stats { get; set; } = new();
+        public IdentityPlaybackPreferences Playback { get; set; } = new();
         public List<string> SourceFiles { get; set; } = new();
     }
 
@@ -91,6 +92,21 @@ internal class YouTubeWarmupService
         public int WatchedMs { get; set; }
             = 0;
         public DateTimeOffset WatchedAt { get; set; } = DateTimeOffset.UtcNow;
+        public string VideoType { get; set; } = string.Empty;
+        public int? VolumePercent { get; set; }
+            = null;
+    }
+
+    private sealed class IdentityPlaybackPreferences
+    {
+        public int MinVolumePercent { get; set; }
+            = 20;
+        public int MaxVolumePercent { get; set; }
+            = 80;
+        public int? LastVolumePercent { get; set; }
+            = null;
+        public double VolumeAdjustmentChance { get; set; }
+            = 0.6;
     }
 
     private sealed class IdentityStats
@@ -165,6 +181,10 @@ internal class YouTubeWarmupService
             = null;
         public string? ParentContext { get; set; }
             = null;
+        public YouTubeUrlHelper.YouTubeVideoKind VideoType { get; set; }
+            = YouTubeUrlHelper.YouTubeVideoKind.Unknown;
+        public int? VolumePercent { get; set; }
+            = null;
     }
 
     private sealed class SessionInteraction
@@ -195,6 +215,9 @@ internal class YouTubeWarmupService
         public string? ParentVideoTitle { get; set; }
             = null;
         public string? ParentContext { get; set; }
+            = null;
+        public string VideoType { get; set; } = YouTubeUrlHelper.YouTubeVideoKind.Unknown.ToString();
+        public int? VolumePercent { get; set; }
             = null;
     }
 
@@ -497,7 +520,7 @@ internal class YouTubeWarmupService
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         var result = await WatchVideoAsync(
             warmup,
-            context: "Home",
+            context: "RecommendationHome",
             method: "HomeRecommendation",
             contextDetail: $"HomeRecommendation#{index + 1}",
             entryPoint: "Home",
@@ -623,6 +646,120 @@ internal class YouTubeWarmupService
         return false;
     }
 
+    private async Task<int?> MaybeAdjustVolumeAsync(IPage page)
+    {
+        var playback = _identityDocument?.Playback;
+        if (playback == null)
+        {
+            return null;
+        }
+
+        playback.MinVolumePercent = Math.Clamp(playback.MinVolumePercent, 0, 100);
+        playback.MaxVolumePercent = Math.Clamp(playback.MaxVolumePercent, 0, 100);
+        if (playback.MinVolumePercent > playback.MaxVolumePercent)
+        {
+            (playback.MinVolumePercent, playback.MaxVolumePercent) = (playback.MaxVolumePercent, playback.MinVolumePercent);
+        }
+
+        playback.VolumeAdjustmentChance = Math.Clamp(playback.VolumeAdjustmentChance, 0, 1);
+        if (playback.VolumeAdjustmentChance <= 0)
+        {
+            playback.VolumeAdjustmentChance = 0.6;
+        }
+
+        if (_random.NextDouble() > playback.VolumeAdjustmentChance)
+        {
+            return playback.LastVolumePercent;
+        }
+
+        double? currentVolume = null;
+        try
+        {
+            currentVolume = await page.EvaluateAsync<double?>("() => { const video = document.querySelector('video'); return video ? video.volume : null; }");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to read current YouTube volume.");
+        }
+
+        int min = playback.MinVolumePercent;
+        int max = playback.MaxVolumePercent;
+        int targetPercent = min == max ? min : _random.Next(min, max + 1);
+        double targetVolume = Math.Clamp(targetPercent / 100.0, 0, 1);
+
+        if (currentVolume.HasValue && Math.Abs(currentVolume.Value - targetVolume) < 0.03 && _random.NextDouble() < 0.4)
+        {
+            int currentPercent = Math.Clamp((int)Math.Round(currentVolume.Value * 100), 0, 100);
+            playback.LastVolumePercent = currentPercent;
+            return currentPercent;
+        }
+
+        var videoLocator = page.Locator("video.html5-main-video, ytd-player video");
+        try
+        {
+            if (await videoLocator.CountAsync() > 0)
+            {
+                if (_mouseHelper != null)
+                {
+                    await _mouseHelper.MoveAndClickAsync(videoLocator.First);
+                }
+                else
+                {
+                    await videoLocator.First.ClickAsync();
+                }
+
+                await Task.Delay(_random.Next(120, 260));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to focus video element before adjusting volume.");
+        }
+
+        bool usedKeyboard = _random.NextDouble() < 0.65;
+        if (usedKeyboard)
+        {
+            double startingVolume = currentVolume ?? (playback.LastVolumePercent.HasValue ? playback.LastVolumePercent.Value / 100.0 : 0.5);
+            double step = 0.05;
+            int steps = (int)Math.Round((targetVolume - startingVolume) / step);
+            string key = steps >= 0 ? "ArrowUp" : "ArrowDown";
+
+            for (int i = 0; i < Math.Abs(steps); i++)
+            {
+                await page.Keyboard.PressAsync(key);
+                await Task.Delay(_random.Next(70, 150));
+            }
+        }
+        else
+        {
+            try
+            {
+                await page.EvaluateAsync("(vol) => { const video = document.querySelector('video'); if (video) { video.volume = Math.min(1, Math.max(0, vol)); } }", targetVolume);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "Failed to set YouTube volume via script.");
+            }
+        }
+
+        double? finalVolume = null;
+        try
+        {
+            finalVolume = await page.EvaluateAsync<double?>("() => { const video = document.querySelector('video'); return video ? video.volume : null; }");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to read final YouTube volume.");
+        }
+
+        int? finalPercent = finalVolume.HasValue
+            ? (int?)Math.Clamp((int)Math.Round(finalVolume.Value * 100), 0, 100)
+            : targetPercent;
+
+        playback.LastVolumePercent = finalPercent;
+        return finalPercent;
+    }
+
     private async Task<VideoWatchResult?> WatchVideoAsync(
         YouTubeWarmupSettings warmup,
         string context,
@@ -643,6 +780,7 @@ internal class YouTubeWarmupService
             _logger?.LogWarning("Video element did not appear for context {Context}.", context);
         }
 
+        int? volumePercent = await MaybeAdjustVolumeAsync(page);
         int planned = PlanWatchDuration(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
         int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
         var start = DateTimeOffset.Now;
@@ -662,12 +800,35 @@ internal class YouTubeWarmupService
             await ScrollHelper.ScrollRandomAsync(page, _random.Next(1, 4));
         }
 
-        if (_random.NextDouble() < 0.25)
+        double detailRoll = _random.NextDouble();
+        if (detailRoll < 0.25)
         {
             var showMore = page.Locator("#expand, tp-yt-paper-button#expand, #more");
             if (await showMore.CountAsync() > 0 && await showMore.IsVisibleAsync())
             {
-                await _mouseHelper!.MoveAndClickAsync(showMore);
+                if (_mouseHelper != null)
+                {
+                    await _mouseHelper.MoveAndClickAsync(showMore);
+                }
+                else
+                {
+                    await showMore.First.ClickAsync();
+                }
+            }
+        }
+        else if (detailRoll < 0.35)
+        {
+            var collapse = page.Locator("#collapse, tp-yt-paper-button#collapse");
+            if (await collapse.CountAsync() > 0 && await collapse.IsVisibleAsync())
+            {
+                if (_mouseHelper != null)
+                {
+                    await _mouseHelper.MoveAndClickAsync(collapse);
+                }
+                else
+                {
+                    await collapse.First.ClickAsync();
+                }
             }
         }
 
@@ -690,8 +851,12 @@ internal class YouTubeWarmupService
             IsShort = false,
             ParentVideoUrl = parent?.Url,
             ParentVideoTitle = parent?.Title,
-            ParentContext = parent?.ContextDetail ?? parent?.Context
+            ParentContext = parent?.ContextDetail ?? parent?.Context,
+            VolumePercent = volumePercent
         };
+
+        result.VideoType = YouTubeUrlHelper.GetVideoKind(result.Url);
+        result.IsShort = result.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short;
 
         RecordVideoWatch(result);
         return result;
@@ -707,6 +872,7 @@ internal class YouTubeWarmupService
         VideoWatchResult? parent)
     {
         var page = await EnsurePageAsync();
+        int? volumePercent = await MaybeAdjustVolumeAsync(page);
         int planned = PlanWatchDuration(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
         int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
         var start = DateTimeOffset.Now;
@@ -738,8 +904,12 @@ internal class YouTubeWarmupService
             IsShort = true,
             ParentVideoUrl = parent?.Url,
             ParentVideoTitle = parent?.Title,
-            ParentContext = parent?.ContextDetail ?? parent?.Context
+            ParentContext = parent?.ContextDetail ?? parent?.Context,
+            VolumePercent = volumePercent
         };
+
+        result.VideoType = YouTubeUrlHelper.GetVideoKind(result.Url);
+        result.IsShort = result.VideoType == YouTubeUrlHelper.YouTubeVideoKind.Short;
 
         RecordVideoWatch(result);
         return result;
@@ -815,9 +985,11 @@ internal class YouTubeWarmupService
                 break;
             }
 
+            string recommendationContext = "RecommendationNext";
+
             var result = await WatchVideoAsync(
                 warmup,
-                context: "Recommendation",
+                context: recommendationContext,
                 method: method,
                 contextDetail: contextDetail,
                 entryPoint: parent.EntryPoint,
@@ -1185,6 +1357,41 @@ internal class YouTubeWarmupService
         }
 
         document.SourceFiles ??= new List<string>();
+        if (document.Playback == null)
+        {
+            document.Playback = CreatePlaybackPreferences();
+            updated = true;
+        }
+        if (document.Playback.MinVolumePercent < 0 || document.Playback.MinVolumePercent > 100)
+        {
+            document.Playback.MinVolumePercent = 20;
+            updated = true;
+        }
+        if (document.Playback.MaxVolumePercent < 0 || document.Playback.MaxVolumePercent > 100)
+        {
+            document.Playback.MaxVolumePercent = 80;
+            updated = true;
+        }
+        if (document.Playback.MinVolumePercent > document.Playback.MaxVolumePercent)
+        {
+            (document.Playback.MinVolumePercent, document.Playback.MaxVolumePercent) = (document.Playback.MaxVolumePercent, document.Playback.MinVolumePercent);
+            updated = true;
+        }
+        if (document.Playback.VolumeAdjustmentChance <= 0 || document.Playback.VolumeAdjustmentChance > 1)
+        {
+            document.Playback.VolumeAdjustmentChance = 0.6;
+            updated = true;
+        }
+        else
+        {
+            double clampedChance = Math.Clamp(document.Playback.VolumeAdjustmentChance, 0, 1);
+            if (!document.Playback.VolumeAdjustmentChance.Equals(clampedChance))
+            {
+                document.Playback.VolumeAdjustmentChance = clampedChance;
+                updated = true;
+            }
+        }
+
         document.Stats ??= new IdentityStats();
         document.Stats.SourceDistribution ??= new SourceBreakdown();
 
@@ -1203,6 +1410,27 @@ internal class YouTubeWarmupService
         {
             await SaveIdentityAsync();
         }
+    }
+
+    private IdentityPlaybackPreferences CreatePlaybackPreferences()
+    {
+        int min = _random.Next(10, 41);
+        int maxLowerBound = Math.Max(min + 15, 55);
+        maxLowerBound = Math.Min(maxLowerBound, 95);
+        int max = _random.Next(maxLowerBound, 101);
+        if (max < min)
+        {
+            max = Math.Min(90, min + 10);
+        }
+
+        double chance = 0.45 + _random.NextDouble() * 0.35;
+
+        return new IdentityPlaybackPreferences
+        {
+            MinVolumePercent = Math.Clamp(min, 0, 100),
+            MaxVolumePercent = Math.Clamp(Math.Max(max, min + 5), 0, 100),
+            VolumeAdjustmentChance = Math.Clamp(chance, 0.1, 0.95)
+        };
     }
 
     private async Task<YouTubeIdentityDocument> CreateNewIdentityDocumentAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
@@ -1246,6 +1474,7 @@ internal class YouTubeWarmupService
                 LastUpdated = DateTimeOffset.UtcNow,
                 SourceDistribution = new SourceBreakdown()
             },
+            Playback = CreatePlaybackPreferences(),
             SourceFiles = sources
         };
     }
@@ -1343,13 +1572,17 @@ internal class YouTubeWarmupService
                 Keyword = result.Keyword!,
                 VideoUrl = result.Url!,
                 WatchedMs = result.ActualWatchDurationMs,
-                WatchedAt = result.StartedAt
+                WatchedAt = result.StartedAt,
+                VideoType = result.VideoType.ToString(),
+                VolumePercent = result.VolumePercent
             });
         }
         else
         {
             existing.WatchedMs = result.ActualWatchDurationMs;
             existing.WatchedAt = result.StartedAt;
+            existing.VideoType = result.VideoType.ToString();
+            existing.VolumePercent = result.VolumePercent;
         }
 
         const int maxHistory = 200;
@@ -1368,7 +1601,7 @@ internal class YouTubeWarmupService
         string channel = rawChannel ?? "(unknown)";
 
         _logger?.LogInformation(
-            "YouTube watch identity={Identity} entry={Entry} context={Context} detail={Detail} method={Method} url={Url} title={Title} channel={Channel} planned_ms={Planned} actual_ms={Actual} started={Started:o} short={IsShort} parent={Parent}.",
+            "YouTube watch identity={Identity} entry={Entry} context={Context} detail={Detail} method={Method} url={Url} title={Title} channel={Channel} type={Type} planned_ms={Planned} actual_ms={Actual} started={Started:o} short={IsShort} volume={Volume} parent={Parent}.",
             _identityKey,
             result.EntryPoint,
             result.Context,
@@ -1377,10 +1610,12 @@ internal class YouTubeWarmupService
             result.Url ?? "unknown",
             title,
             channel,
+            result.VideoType,
             result.PlannedWatchDurationMs,
             result.ActualWatchDurationMs,
             result.StartedAt,
             result.IsShort,
+            result.VolumePercent,
             result.ParentVideoUrl ?? "none");
 
         var interaction = new SessionInteraction
@@ -1400,7 +1635,9 @@ internal class YouTubeWarmupService
             IsShort = result.IsShort,
             ParentVideo = result.ParentVideoUrl,
             ParentVideoTitle = result.ParentVideoTitle,
-            ParentContext = result.ParentContext
+            ParentContext = result.ParentContext,
+            VideoType = result.VideoType.ToString(),
+            VolumePercent = result.VolumePercent
         };
 
         _sessionInteractions.Add(interaction);
@@ -1417,6 +1654,11 @@ internal class YouTubeWarmupService
             _sessionSourceCounts[entryPoint] = 0;
         }
         _sessionSourceCounts[entryPoint]++;
+
+        if (result.VolumePercent.HasValue && _identityDocument?.Playback != null)
+        {
+            _identityDocument.Playback.LastVolumePercent = Math.Clamp(result.VolumePercent.Value, 0, 100);
+        }
 
         UpdateKeywordHistory(result);
     }

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -483,6 +483,395 @@ internal class YouTubeWarmupService
             async settings => await _homeService!.ExecuteAsync(settings));
     }
 
+    private async Task EnsureIdentityAsync(string? keywordDirectory, YouTubeWarmupSettings warmup, string? profileKey)
+    {
+        _identityKey = string.IsNullOrWhiteSpace(profileKey) ? "default" : profileKey;
+
+        string identityRoot = ResolvePath(warmup.IdentityCacheDirectory, "youtube-identities");
+        _identityDirectory = Path.Combine(identityRoot, SanitizeFileName(_identityKey));
+        _sessionsDirectory = Path.Combine(_identityDirectory, "sessions");
+        _identityPath = Path.Combine(_identityDirectory, "identity.json");
+
+        Directory.CreateDirectory(_identityDirectory);
+        Directory.CreateDirectory(_sessionsDirectory);
+
+        if (_identityDocument == null && File.Exists(_identityPath))
+        {
+            try
+            {
+                string json = await File.ReadAllTextAsync(_identityPath);
+                _identityDocument = JsonSerializer.Deserialize<YouTubeIdentityDocument>(json);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to deserialize YouTube identity from {Path}.", _identityPath);
+            }
+        }
+
+        if (_identityDocument == null)
+        {
+            _identityDocument = new YouTubeIdentityDocument
+            {
+                Profile = new IdentityProfileInfo
+                {
+                    ProfileId = _identityKey,
+                    Persona = warmup.Persona,
+                    Region = warmup.Region,
+                    Language = warmup.Language,
+                    Domain = warmup.Domains?.FirstOrDefault() ?? "https://www.youtube.com",
+                    Timezone = !string.IsNullOrWhiteSpace(warmup.Timezone) ? warmup.Timezone : TimeZoneInfo.Local.Id,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    LastUpdated = DateTimeOffset.UtcNow,
+                    Behaviors = warmup.Behaviors ?? Array.Empty<string>()
+                },
+                Keywords = new KeywordSection(),
+                Stats = new IdentityStats(),
+                Playback = new IdentityPlaybackPreferences(),
+                SourceFiles = new List<string>()
+            };
+        }
+
+        _identityDocument.Profile ??= new IdentityProfileInfo();
+        _identityDocument.Profile.ProfileId = string.IsNullOrWhiteSpace(_identityDocument.Profile.ProfileId)
+            ? _identityKey
+            : _identityDocument.Profile.ProfileId;
+        if (string.IsNullOrWhiteSpace(_identityDocument.Profile.Domain))
+        {
+            _identityDocument.Profile.Domain = warmup.Domains?.FirstOrDefault() ?? "https://www.youtube.com";
+        }
+        _identityDocument.Profile.Behaviors = _identityDocument.Profile.Behaviors?.Length > 0
+            ? _identityDocument.Profile.Behaviors
+            : (warmup.Behaviors ?? Array.Empty<string>());
+
+        _identityDocument.Keywords ??= new KeywordSection();
+        _identityDocument.Keywords.UsedHistory ??= new List<KeywordUsageRecord>();
+        _identityDocument.Keywords.KeywordHistory ??= new List<KeywordVideoRecord>();
+        _identityDocument.Playback ??= new IdentityPlaybackPreferences();
+        _identityDocument.Stats ??= new IdentityStats();
+        _identityDocument.SourceFiles ??= new List<string>();
+
+        var keywordSet = new HashSet<string>(_identityDocument.Keywords.SeedList ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        if (keywordSet.Count == 0)
+        {
+            var fromDirectory = LoadKeywordsFromDirectory(keywordDirectory, warmup.IdentityKeywordFileCount);
+            foreach (var keyword in fromDirectory)
+            {
+                keywordSet.Add(keyword);
+            }
+
+            if (keywordSet.Count == 0)
+            {
+                foreach (var fallback in FallbackKeywords)
+                {
+                    keywordSet.Add(fallback);
+                }
+            }
+
+            _identityDocument.Keywords.SeedList = keywordSet.ToList();
+        }
+
+        _identityKeywords.Clear();
+        _identityKeywords.AddRange(keywordSet);
+    }
+
+    private List<string> LoadKeywordsFromDirectory(string? keywordDirectory, int desiredFileCount)
+    {
+        var results = new List<string>();
+        if (string.IsNullOrWhiteSpace(keywordDirectory))
+        {
+            return results;
+        }
+
+        string resolvedDirectory = ResolvePath(keywordDirectory, keywordDirectory);
+        if (!Directory.Exists(resolvedDirectory))
+        {
+            _logger?.LogDebug("Keyword directory {Directory} does not exist.", resolvedDirectory);
+            return results;
+        }
+
+        var files = Directory.EnumerateFiles(resolvedDirectory, "*.txt", SearchOption.AllDirectories).ToList();
+        if (files.Count == 0)
+        {
+            return results;
+        }
+
+        files = files.OrderBy(_ => _random.Next()).ToList();
+        int takeCount = desiredFileCount <= 0 ? files.Count : Math.Min(desiredFileCount, files.Count);
+        var selectedFiles = files.Take(takeCount).ToList();
+
+        _identityDocument?.SourceFiles?.Clear();
+        _identityDocument?.SourceFiles?.AddRange(selectedFiles);
+
+        foreach (var file in selectedFiles)
+        {
+            try
+            {
+                foreach (var line in File.ReadAllLines(file))
+                {
+                    var trimmed = line.Trim();
+                    if (!string.IsNullOrWhiteSpace(trimmed))
+                    {
+                        results.Add(trimmed);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "Failed to read keywords from {File}.", file);
+            }
+        }
+
+        return results;
+    }
+
+    private static string ResolvePath(string? candidate, string? defaultRelative)
+    {
+        string baseDirectory = AppContext.BaseDirectory ?? Environment.CurrentDirectory;
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return string.IsNullOrWhiteSpace(defaultRelative)
+                ? baseDirectory
+                : Path.Combine(baseDirectory, defaultRelative);
+        }
+
+        if (Path.IsPathRooted(candidate))
+        {
+            return candidate;
+        }
+
+        return Path.Combine(baseDirectory, candidate);
+    }
+
+    private void RegisterInteractionFailure()
+    {
+        _sessionFailureCount++;
+        if (_identityDocument?.Stats != null)
+        {
+            _identityDocument.Stats.FailedInteractions++;
+            _identityDocument.Stats.LastUpdated = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private void RecordVideoWatch(VideoWatchResult result)
+    {
+        if (result == null)
+        {
+            return;
+        }
+
+        var interaction = new SessionInteraction
+        {
+            Context = result.Context,
+            ContextDetail = result.ContextDetail,
+            EntryPoint = result.EntryPoint,
+            Method = result.Method,
+            ResultPosition = result.ResultPosition,
+            Keyword = result.Keyword,
+            VideoUrl = result.Url,
+            Title = result.Title,
+            ChannelName = result.ChannelName,
+            PlannedWatchMs = result.PlannedWatchDurationMs,
+            ActualWatchMs = result.ActualWatchDurationMs,
+            StartedAt = result.StartedAt,
+            IsShort = result.IsShort,
+            ParentVideo = result.ParentVideoUrl,
+            ParentVideoTitle = result.ParentVideoTitle,
+            ParentContext = result.ParentContext,
+            VideoType = result.VideoType.ToString(),
+            VolumePercent = result.VolumePercent
+        };
+
+        _sessionInteractions.Add(interaction);
+        _sessionTotalWatchTimeMs += result.ActualWatchDurationMs;
+
+        if (IsBounce(result))
+        {
+            _sessionBounceCount++;
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.EntryPoint))
+        {
+            string key = result.EntryPoint;
+            _sessionSourceCounts.TryGetValue(key, out var count);
+            _sessionSourceCounts[key] = count + 1;
+        }
+
+        if (_identityDocument?.Keywords != null && !string.IsNullOrWhiteSpace(result.Keyword) && !string.IsNullOrWhiteSpace(result.Url))
+        {
+            _identityDocument.Keywords.KeywordHistory ??= new List<KeywordVideoRecord>();
+            _identityDocument.Keywords.KeywordHistory.Add(new KeywordVideoRecord
+            {
+                Keyword = result.Keyword!,
+                VideoUrl = result.Url!,
+                WatchedMs = result.ActualWatchDurationMs,
+                WatchedAt = result.StartedAt,
+                VideoType = result.VideoType.ToString(),
+                VolumePercent = result.VolumePercent
+            });
+
+            const int maxHistory = 200;
+            if (_identityDocument.Keywords.KeywordHistory.Count > maxHistory)
+            {
+                int excess = _identityDocument.Keywords.KeywordHistory.Count - maxHistory;
+                _identityDocument.Keywords.KeywordHistory.RemoveRange(0, excess);
+            }
+        }
+
+        if (_identityDocument?.Playback != null && result.VolumePercent.HasValue)
+        {
+            _identityDocument.Playback.LastVolumePercent = result.VolumePercent;
+        }
+    }
+
+    private async Task NavigateHomeAsync()
+    {
+        var page = await EnsurePageAsync();
+        string previousUrl = page.Url ?? string.Empty;
+        string target = GetBaseYouTubeDomain().TrimEnd('/') + "/";
+
+        if (string.Equals(page.Url, target, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            await page.GotoAsync(target, new PageGotoOptions
+            {
+                Timeout = 60000,
+                WaitUntil = WaitUntilState.DOMContentLoaded
+            });
+            await WaitForNavigationAsync(page, previousUrl);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed navigating home to {Target}.", target);
+        }
+    }
+
+    private void RegisterKeywordUsage(string keyword)
+    {
+        if (string.IsNullOrWhiteSpace(keyword) || _identityDocument?.Keywords == null)
+        {
+            return;
+        }
+
+        var history = _identityDocument.Keywords.UsedHistory ??= new List<KeywordUsageRecord>();
+        var record = history.FirstOrDefault(r => string.Equals(r.Keyword, keyword, StringComparison.OrdinalIgnoreCase));
+        if (record == null)
+        {
+            record = new KeywordUsageRecord
+            {
+                Keyword = keyword,
+                TimesUsed = 1,
+                LastUsed = DateTimeOffset.UtcNow
+            };
+            history.Add(record);
+        }
+        else
+        {
+            record.TimesUsed++;
+            record.LastUsed = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private async Task<ILocator> FocusSearchBoxAsync()
+    {
+        var page = await EnsurePageAsync();
+        var input = page.Locator("input#search, input[name='search_query']").First;
+
+        await input.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+
+        bool isFocused = await IsElementFocusedAsync(input);
+        if (!isFocused)
+        {
+            if (_mouseHelper != null)
+            {
+                await _mouseHelper.MoveAndClickAsync(input);
+            }
+            else
+            {
+                await input.ClickAsync(new LocatorClickOptions { Delay = _random.Next(80, 200) });
+            }
+        }
+
+        await Task.Delay(_random.Next(120, 260));
+        return input;
+    }
+
+    private async Task ClearInputAsync(ILocator input)
+    {
+        if (!await IsElementFocusedAsync(input))
+        {
+            await input.ClickAsync(new LocatorClickOptions { Delay = _random.Next(60, 160) });
+        }
+
+        try
+        {
+            await input.PressAsync("Control+A");
+            await Task.Delay(_random.Next(80, 180));
+            await input.PressAsync("Delete");
+        }
+        catch
+        {
+            // Fall back to direct fill if key-based clearing fails (e.g., macOS meta key)
+            try
+            {
+                await input.FillAsync(string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "Failed to clear YouTube search input.");
+            }
+        }
+
+        await Task.Delay(_random.Next(120, 240));
+    }
+
+    private async Task<bool> IsElementFocusedAsync(ILocator locator)
+    {
+        try
+        {
+            return await locator.EvaluateAsync<bool>("el => document.activeElement === el");
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private Task<string> PickKeywordAsync(string? keywordDirectory)
+    {
+        if (_identityKeywords.Count == 0)
+        {
+            var fallback = LoadKeywordsFromDirectory(keywordDirectory, 1);
+            if (fallback.Count == 0)
+            {
+                fallback.AddRange(FallbackKeywords);
+            }
+
+            _identityKeywords.AddRange(fallback);
+        }
+
+        var usageLookup = _identityDocument?.Keywords?.UsedHistory?
+            .ToDictionary(k => k.Keyword, k => k, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, KeywordUsageRecord>(StringComparer.OrdinalIgnoreCase);
+
+        var ordered = _identityKeywords
+            .OrderBy(k => usageLookup.TryGetValue(k, out var record) ? record.TimesUsed : 0)
+            .ThenBy(k => usageLookup.TryGetValue(k, out var record) ? record.LastUsed ?? DateTimeOffset.MinValue : DateTimeOffset.MinValue)
+            .ThenBy(_ => _random.Next())
+            .ToList();
+
+        if (ordered.Count == 0)
+        {
+            return Task.FromResult(FallbackKeywords[_random.Next(FallbackKeywords.Length)]);
+        }
+
+        int poolSize = Math.Min(ordered.Count, Math.Max(3, ordered.Count / 3));
+        return Task.FromResult(ordered[_random.Next(poolSize)]);
+    }
+
     private Task PauseAfterPlaybackAsync() => Task.Delay(_random.Next(400, 900));
 
     private YouTubeWarmupService.IdentityPlaybackPreferences? GetPlaybackPreferences()

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -448,7 +448,7 @@ internal class YouTubeWarmupService
 
         _homeService ??= new HomeInteractionService(
             EnsurePageAsync,
-            NavigateHomeAsync,
+            async _ => await NavigateHomeAsync(),
             _videoPlayer,
             _recommendationService,
             WaitForNavigationAsync,
@@ -541,7 +541,7 @@ internal class YouTubeWarmupService
         }
         _identityDocument.Profile.Behaviors = _identityDocument.Profile.Behaviors?.Length > 0
             ? _identityDocument.Profile.Behaviors
-            : (warmup.Behaviors ?? Array.Empty<string>());
+            : (warmup.Behaviors != null ? warmup.Behaviors.ToArray() : Array.Empty<string>());
 
         _identityDocument.Keywords ??= new KeywordSection();
         _identityDocument.Keywords.UsedHistory ??= new List<KeywordUsageRecord>();

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -1,0 +1,461 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services;
+
+internal class YouTubeWarmupService
+{
+    private readonly IBrowserContext _context;
+    private readonly ILogger<YouTubeWarmupService>? _logger;
+    private readonly Random _random = RandomProvider.Shared;
+
+    private IPage? _page;
+    private MouseHelper? _mouseHelper;
+    private KeyboardHelper? _keyboardHelper;
+    private bool _isFirstRun = true;
+
+    private static readonly string[] FallbackKeywords = new[]
+    {
+        "daily vlog",
+        "music playlist",
+        "travel guide",
+        "technology review",
+        "recipe tutorial",
+        "gaming highlights"
+    };
+
+    public YouTubeWarmupService(IBrowserContext context, ILogger<YouTubeWarmupService>? logger = null)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger;
+    }
+
+    public async Task RunWarmupAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    {
+        if (warmup is null)
+        {
+            throw new ArgumentNullException(nameof(warmup));
+        }
+
+        if (!warmup.Enabled)
+        {
+            _logger?.LogInformation("YouTube warmup disabled. Skipping.");
+            return;
+        }
+
+        if (warmup.MinInteractions < 1)
+        {
+            warmup.MinInteractions = 1;
+        }
+
+        if (warmup.MaxInteractions < warmup.MinInteractions)
+        {
+            warmup.MaxInteractions = warmup.MinInteractions;
+        }
+
+        if (warmup.MinWatchMilliseconds <= 0 || warmup.MinWatchMilliseconds > warmup.MaxWatchMilliseconds)
+        {
+            warmup.MinWatchMilliseconds = Math.Min(15000, warmup.MaxWatchMilliseconds);
+        }
+
+        if (warmup.MinShortWatchMilliseconds <= 0 || warmup.MinShortWatchMilliseconds > warmup.MaxShortWatchMilliseconds)
+        {
+            warmup.MinShortWatchMilliseconds = Math.Min(8000, warmup.MaxShortWatchMilliseconds);
+        }
+
+        int completed = 0;
+        while (true)
+        {
+            try
+            {
+                await EnsureOnYouTubeAsync(warmup);
+                await PerformInteractionAsync(keywordDirectory, warmup);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "YouTube interaction failed.");
+            }
+
+            _isFirstRun = false;
+            completed++;
+
+            if (completed >= warmup.MaxInteractions)
+            {
+                _logger?.LogInformation("Reached max YouTube interactions ({Count}). Ending warmup.", completed);
+                break;
+            }
+
+            if (completed < warmup.MinInteractions)
+            {
+                _logger?.LogInformation("Completed {Count} YouTube interactions but minimum is {Minimum}. Continuing.", completed, warmup.MinInteractions);
+                await PauseBetweenActionsAsync(warmup);
+                continue;
+            }
+
+            double roll = _random.NextDouble();
+            if (roll >= warmup.ContinueProbability)
+            {
+                _logger?.LogInformation("Stopping YouTube warmup after {Count} interactions (roll={Roll:0.00} threshold={Threshold:0.00}).", completed, roll, warmup.ContinueProbability);
+                break;
+            }
+
+            _logger?.LogInformation("Continuing YouTube warmup after {Count} interactions (roll={Roll:0.00}).", completed, roll);
+            await PauseBetweenActionsAsync(warmup);
+        }
+    }
+
+    private async Task PerformInteractionAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    {
+        double normalizedSearchWeight = Math.Clamp(warmup.SearchWeight, 0, 1);
+        double normalizedShortsWeight = Math.Clamp(warmup.ShortsWeight, 0, 1 - normalizedSearchWeight);
+        double homeWeight = 1 - normalizedSearchWeight - normalizedShortsWeight;
+
+        double roll = _random.NextDouble();
+        if (_isFirstRun)
+        {
+            roll = Math.Min(roll, normalizedSearchWeight + 0.1);
+        }
+
+        if (roll < normalizedSearchWeight)
+        {
+            _logger?.LogInformation("YouTube warmup selected search interaction.");
+            await SearchAndWatchAsync(keywordDirectory, warmup);
+            return;
+        }
+
+        if (roll < normalizedSearchWeight + normalizedShortsWeight)
+        {
+            _logger?.LogInformation("YouTube warmup selected Shorts interaction.");
+            bool success = await OpenShortsAsync(warmup);
+            if (!success)
+            {
+                _logger?.LogInformation("Shorts interaction unavailable; falling back to home recommendation.");
+                await WatchFromHomeAsync(warmup);
+            }
+            return;
+        }
+
+        _logger?.LogInformation("YouTube warmup selected home recommendation interaction (weight={Weight:0.00}).", homeWeight);
+        await WatchFromHomeAsync(warmup);
+    }
+
+    private async Task<IPage> EnsurePageAsync()
+    {
+        if (_page != null && !_page.IsClosed)
+        {
+            return _page;
+        }
+
+        var existing = _context.Pages.FirstOrDefault(p => !p.IsClosed);
+        _page = existing ?? await _context.NewPageAsync();
+        _mouseHelper = new MouseHelper(_page);
+        _keyboardHelper = new KeyboardHelper(_page);
+        return _page;
+    }
+
+    private async Task EnsureOnYouTubeAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
+        string? url = page.Url;
+        if (!IsOnYouTube(url))
+        {
+            string domain = ChooseDomain(warmup);
+            _logger?.LogInformation("Navigating to YouTube domain {Domain} (current={Url}).", domain, url ?? "unknown");
+            await page.GotoAsync(domain, new PageGotoOptions
+            {
+                Timeout = 60000,
+                WaitUntil = WaitUntilState.DOMContentLoaded
+            });
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Task.Delay(_random.Next(1000, 2500));
+        }
+    }
+
+    private async Task SearchAndWatchAsync(string? keywordDirectory, YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
+        await EnsureOnYouTubeAsync(warmup);
+
+        string keyword = await PickKeywordAsync(keywordDirectory);
+        _logger?.LogInformation("Searching YouTube for '{Keyword}'.", keyword);
+
+        var input = await FocusSearchBoxAsync();
+        await ClearInputAsync(input);
+        await _keyboardHelper!.TypeLikeHumanAsync(input, keyword);
+        await Task.Delay(_random.Next(400, 1200));
+
+        double decision = _random.NextDouble();
+        if (decision < 0.4)
+        {
+            var searchButton = page.Locator("button#search-icon-legacy");
+            if (await searchButton.CountAsync() > 0 && await searchButton.IsVisibleAsync())
+            {
+                await _mouseHelper!.MoveAndClickAsync(searchButton);
+            }
+            else
+            {
+                await input.PressAsync("Enter");
+            }
+        }
+        else if (decision < 0.75)
+        {
+            await input.PressAsync("Enter");
+        }
+        else
+        {
+            await _mouseHelper!.MoveAndClickAsync(input);
+            await input.PressAsync("Enter");
+        }
+
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await Task.Delay(_random.Next(1200, 2500));
+
+        var videoTiles = page.Locator("ytd-video-renderer a#thumbnail, ytd-grid-video-renderer a#thumbnail");
+        if (await videoTiles.CountAsync() == 0)
+        {
+            _logger?.LogWarning("No YouTube search results were found.");
+            return;
+        }
+
+        int index = _random.Next(0, await videoTiles.CountAsync());
+        var target = videoTiles.Nth(index);
+        _logger?.LogInformation("Opening YouTube search result #{Index}.", index + 1);
+        await ScrollHelper.ScrollToElementAsync(page, target);
+        await _mouseHelper!.MoveAndClickAsync(target);
+
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await WatchVideoAsync(warmup);
+    }
+
+    private async Task WatchFromHomeAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
+        await NavigateHomeAsync(warmup);
+
+        var richItems = page.Locator("#contents ytd-rich-item-renderer a#thumbnail");
+        int count = await richItems.CountAsync();
+        if (count == 0)
+        {
+            _logger?.LogWarning("No rich items on YouTube home page. Trying search fallback.");
+            await SearchAndWatchAsync(null, warmup);
+            return;
+        }
+
+        int index = _random.Next(0, count);
+        var target = richItems.Nth(index);
+        _logger?.LogInformation("Opening YouTube home recommendation #{Index} of {Total}.", index + 1, count);
+        await ScrollHelper.ScrollToElementAsync(page, target);
+        await _mouseHelper!.MoveAndClickAsync(target);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await WatchVideoAsync(warmup);
+    }
+
+    private async Task<bool> OpenShortsAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
+        await EnsureOnYouTubeAsync(warmup);
+
+        var shortsLink = page.Locator("ytd-mini-guide-entry-renderer a[href*='shorts'], a[title='Shorts']");
+        if (!await shortsLink.IsVisibleAsync())
+        {
+            var menuButton = page.Locator("button#guide-button, #guide-button");
+            if (await menuButton.CountAsync() > 0 && await menuButton.IsVisibleAsync())
+            {
+                await _mouseHelper!.MoveAndClickAsync(menuButton);
+                await Task.Delay(_random.Next(600, 1200));
+            }
+        }
+
+        if (!await shortsLink.IsVisibleAsync())
+        {
+            return false;
+        }
+
+        await _mouseHelper!.MoveAndClickAsync(shortsLink);
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await Task.Delay(_random.Next(1000, 2000));
+
+        var shortsTiles = page.Locator("ytd-reel-video-renderer a#thumbnail, ytd-reel-item-renderer a#thumbnail");
+        int count = await shortsTiles.CountAsync();
+        if (count == 0)
+        {
+            _logger?.LogWarning("No shorts available after navigating to Shorts page.");
+            return true;
+        }
+
+        int index = _random.Next(0, count);
+        var target = shortsTiles.Nth(index);
+        _logger?.LogInformation("Opening YouTube short #{Index} of {Total}.", index + 1, count);
+        await _mouseHelper!.MoveAndClickAsync(target);
+        await page.WaitForTimeoutAsync(_random.Next(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds + 1));
+        return true;
+    }
+
+    private async Task WatchVideoAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
+        int watchMs = _random.Next(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds + 1);
+        _logger?.LogInformation("Watching YouTube video for approximately {Seconds:0.0} seconds.", watchMs / 1000.0);
+        await page.WaitForTimeoutAsync(watchMs);
+
+        if (_random.NextDouble() < 0.3)
+        {
+            await page.Keyboard.PressAsync("Space");
+            await Task.Delay(_random.Next(800, 1500));
+            await page.Keyboard.PressAsync("Space");
+        }
+
+        if (_random.NextDouble() < 0.4)
+        {
+            await ScrollHelper.ScrollRandomAsync(page, _random.Next(1, 4));
+        }
+
+        if (_random.NextDouble() < 0.25)
+        {
+            var showMore = page.Locator("#expand, tp-yt-paper-button#expand, #more");
+            if (await showMore.CountAsync() > 0 && await showMore.IsVisibleAsync())
+            {
+                await _mouseHelper!.MoveAndClickAsync(showMore);
+            }
+        }
+    }
+
+    private async Task NavigateHomeAsync(YouTubeWarmupSettings warmup)
+    {
+        var page = await EnsurePageAsync();
+        string domain = ChooseDomain(warmup);
+        if (!page.Url.StartsWith(domain, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger?.LogInformation("Navigating to YouTube home domain {Domain}.", domain);
+            await page.GotoAsync(domain, new PageGotoOptions
+            {
+                Timeout = 60000,
+                WaitUntil = WaitUntilState.DOMContentLoaded
+            });
+            await Task.Delay(_random.Next(800, 1600));
+            return;
+        }
+
+        var homeLink = page.Locator("ytd-mini-guide-entry-renderer a[title='Home'], ytd-mini-guide-entry-renderer:nth-child(1) a");
+        if (await homeLink.IsVisibleAsync())
+        {
+            await _mouseHelper!.MoveAndClickAsync(homeLink);
+            await Task.Delay(_random.Next(800, 1600));
+        }
+    }
+
+    private async Task<ILocator> FocusSearchBoxAsync()
+    {
+        var page = await EnsurePageAsync();
+        var input = page.Locator("input#search, input[name='search_query']");
+        await input.WaitForAsync(new LocatorWaitForOptions { Timeout = 20000 });
+
+        bool isFocused = false;
+        try
+        {
+            isFocused = await input.EvaluateAsync<bool>("el => document.activeElement === el");
+        }
+        catch
+        {
+            isFocused = false;
+        }
+
+        if (!isFocused)
+        {
+            await _mouseHelper!.MoveAndClickAsync(input);
+        }
+
+        return input;
+    }
+
+    private async Task ClearInputAsync(ILocator input)
+    {
+        string value = string.Empty;
+        try
+        {
+            value = await input.InputValueAsync() ?? string.Empty;
+        }
+        catch
+        {
+            value = string.Empty;
+        }
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        if (_random.NextDouble() < 0.6)
+        {
+            await _page!.Keyboard.PressAsync("Control+A");
+            await Task.Delay(_random.Next(80, 200));
+            await _page.Keyboard.PressAsync("Backspace");
+        }
+        else
+        {
+            await _keyboardHelper!.BackspaceAsync(value.Length, fastCorrection: true);
+        }
+    }
+
+    private async Task<string> PickKeywordAsync(string? keywordDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(keywordDirectory) || !Directory.Exists(keywordDirectory))
+        {
+            return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+        }
+
+        try
+        {
+            var files = Directory.GetFiles(keywordDirectory, "*.txt");
+            if (files.Length == 0)
+            {
+                return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+            }
+
+            var file = files[_random.Next(files.Length)];
+            var keywords = (await File.ReadAllLinesAsync(file))
+                .Select(line => line.Trim())
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .ToArray();
+
+            if (keywords.Length == 0)
+            {
+                return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+            }
+
+            return keywords[_random.Next(keywords.Length)];
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Falling back to default YouTube keywords.");
+            return FallbackKeywords[_random.Next(FallbackKeywords.Length)];
+        }
+    }
+
+    private async Task PauseBetweenActionsAsync(YouTubeWarmupSettings warmup)
+    {
+        int minDelay = Math.Max(500, warmup.MinDelayBetweenActionsMs);
+        int maxDelay = Math.Max(minDelay, warmup.MaxDelayBetweenActionsMs);
+        int pause = _random.Next(minDelay, maxDelay + 1);
+        await Task.Delay(pause);
+    }
+
+    private static bool IsOnYouTube(string? url)
+    {
+        return !string.IsNullOrEmpty(url) && url.Contains("youtube.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string ChooseDomain(YouTubeWarmupSettings warmup)
+    {
+        var domains = warmup.Domains?.Length > 0
+            ? warmup.Domains
+            : new[] { "https://www.youtube.com" };
+        return domains[_random.Next(domains.Length)];
+    }
+}

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -780,6 +780,8 @@ internal class YouTubeWarmupService
             _logger?.LogWarning("Video element did not appear for context {Context}.", context);
         }
 
+        await MaybeSkipAdsAsync(page);
+
         int? volumePercent = await MaybeAdjustVolumeAsync(page);
         int planned = PlanWatchDuration(warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
         int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinWatchMilliseconds, warmup.MaxWatchMilliseconds);
@@ -872,6 +874,8 @@ internal class YouTubeWarmupService
         VideoWatchResult? parent)
     {
         var page = await EnsurePageAsync();
+        await MaybeSkipAdsAsync(page);
+
         int? volumePercent = await MaybeAdjustVolumeAsync(page);
         int planned = PlanWatchDuration(warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
         int actualTarget = ApplyWatchDurationJitter(planned, warmup.MinShortWatchMilliseconds, warmup.MaxShortWatchMilliseconds);
@@ -1036,11 +1040,67 @@ internal class YouTubeWarmupService
         }
     }
 
+    private async Task MaybeSkipAdsAsync(IPage page)
+    {
+        try
+        {
+            var skipSelectors = new[]
+            {
+                "button.ytp-ad-skip-button", // primary skip button
+                ".ytp-ad-skip-button.ytp-button", // legacy skip button style
+                "button.ytp-ad-skip-button-modern", // new UI variant
+                ".ytp-ad-overlay-close-button", // overlay ads
+                "button[aria-label*='Skip'], button[aria-label*='skip']",
+                "#skip-button .ytp-button"
+            };
+
+            for (int attempt = 0; attempt < 6; attempt++)
+            {
+                foreach (string selector in skipSelectors)
+                {
+                    var skipButton = page.Locator(selector);
+                    if (await skipButton.CountAsync() == 0)
+                    {
+                        continue;
+                    }
+
+                    var target = skipButton.First;
+                    if (!await target.IsVisibleAsync())
+                    {
+                        continue;
+                    }
+
+                    _logger?.LogDebug("Attempting to skip YouTube ad using selector {Selector}.", selector);
+                    if (_mouseHelper != null)
+                    {
+                        await _mouseHelper.MoveAndClickAsync(target);
+                    }
+                    else
+                    {
+                        await target.ClickAsync(new LocatorClickOptions { Timeout = 2000 });
+                    }
+
+                    await Task.Delay(_random.Next(600, 1200));
+                    return;
+                }
+
+                await Task.Delay(_random.Next(500, 900));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed while attempting to skip YouTube ads.");
+        }
+    }
+
     private async Task<int?> OpenRecommendedSidebarVideoAsync(IPage page)
     {
         try
         {
-            var recTiles = page.Locator("ytd-compact-video-renderer a#thumbnail, ytd-watch-next-secondary-results-renderer a#thumbnail");
+            var recTiles = page.Locator(
+                "#items > yt-lockup-view-model a#thumbnail, " +
+                "ytd-compact-video-renderer a#thumbnail, " +
+                "ytd-watch-next-secondary-results-renderer a#thumbnail");
             int count = await recTiles.CountAsync();
             if (count == 0)
             {

--- a/appsettings.json
+++ b/appsettings.json
@@ -2,6 +2,9 @@
   "Gpm": {
     "BaseUrl": "http://127.0.0.1:19995",
     "ProxyApiUrl": "https://proxyxoay.shop/api/get.php?key=BnQqcrAVCtRAauUjUUXyXe&&nhamang=random&&tinhthanh=0",
+    "ApiRetryAttempts": 3,
+    "ApiRetryInitialDelayMs": 500,
+    "ApiRetryMaxDelayMs": 8000,
     "Profile": {
       "ProfileName": "Test profile",
       "BrowserCore": "chromium",

--- a/appsettings.json
+++ b/appsettings.json
@@ -30,6 +30,16 @@
   },
   "Search": {
     "SmartSearchKeywordDirectory": "E:/Google_Farm/google",
-    "GoogleKeywordDirectory": "E:/Google_Farm/Keyword_Search/"
+    "GoogleKeywordDirectory": "E:/Google_Farm/Keyword_Search/",
+    "GoogleWarmup": {
+      "MinSearches": 1,
+      "MaxSearches": 3,
+      "ContinueProbability": 0.6,
+      "MaxBacktracks": 2,
+      "Domains": [
+        "https://www.google.com",
+        "https://www.google.com.vn"
+      ]
+    }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,32 @@
+{
+  "Gpm": {
+    "BaseUrl": "http://127.0.0.1:19995",
+    "ProxyApiUrl": "https://proxyxoay.shop/api/get.php?key=BnQqcrAVCtRAauUjUUXyXe&&nhamang=random&&tinhthanh=0",
+    "Profile": {
+      "ProfileName": "Test profile",
+      "BrowserCore": "chromium",
+      "BrowserName": "Chrome",
+      "IsRandomBrowserVersion": false,
+      "StartupUrls": "",
+      "IsMaskedFont": true,
+      "IsNoiseCanvas": true,
+      "IsNoiseWebgl": false,
+      "IsNoiseClientRect": true,
+      "IsNoiseAudioContext": true,
+      "IsRandomScreen": true,
+      "IsMaskedWebglData": true,
+      "IsMaskedMediaDevice": true,
+      "IsRandomOs": false,
+      "OperatingSystems": [
+        "Windows 10",
+        "Windows 11"
+      ],
+      "Os": "Windows 10",
+      "WebrtcMode": 2
+    }
+  },
+  "Search": {
+    "SmartSearchKeywordDirectory": "E:/Google_Farm/google",
+    "GoogleKeywordDirectory": "E:/Google_Farm/Keyword_Search/"
+  }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -58,7 +58,15 @@
       "Domains": [
         "https://www.youtube.com",
         "https://www.youtube.com/feed/explore"
-      ]
+      ],
+      "IdentityCacheDirectory": "youtube-identities",
+      "IdentityKeywordFileCount": 2,
+      "RecommendationChainProbability": 0.6,
+      "MinRecommendationChainLength": 1,
+      "MaxRecommendationChainLength": 3,
+      "AutoplayFollowProbability": 0.4,
+      "MinShortSequenceLength": 2,
+      "MaxShortSequenceLength": 5
     }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -64,6 +64,7 @@
       "RecommendationChainProbability": 0.6,
       "MinRecommendationChainLength": 1,
       "MaxRecommendationChainLength": 3,
+      "MaxRecommendationDepth": 3,
       "AutoplayFollowProbability": 0.4,
       "MinShortSequenceLength": 2,
       "MaxShortSequenceLength": 5,

--- a/appsettings.json
+++ b/appsettings.json
@@ -66,7 +66,16 @@
       "MaxRecommendationChainLength": 3,
       "AutoplayFollowProbability": 0.4,
       "MinShortSequenceLength": 2,
-      "MaxShortSequenceLength": 5
+      "MaxShortSequenceLength": 5,
+      "Persona": "Generalist",
+      "Region": "Global",
+      "Language": "en-US",
+      "Behaviors": [
+        "Search",
+        "Home",
+        "Shorts",
+        "Recommendations"
+      ]
     }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -31,6 +31,7 @@
   "Search": {
     "SmartSearchKeywordDirectory": "E:/Google_Farm/google",
     "GoogleKeywordDirectory": "E:/Google_Farm/Keyword_Search/",
+    "YouTubeKeywordDirectory": "E:/Google_Farm/Keyword_YouTube/",
     "GoogleWarmup": {
       "MinSearches": 1,
       "MaxSearches": 3,
@@ -39,6 +40,24 @@
       "Domains": [
         "https://www.google.com",
         "https://www.google.com.vn"
+      ]
+    },
+    "YouTubeWarmup": {
+      "Enabled": true,
+      "MinInteractions": 2,
+      "MaxInteractions": 4,
+      "ContinueProbability": 0.4,
+      "MinWatchMilliseconds": 25000,
+      "MaxWatchMilliseconds": 60000,
+      "MinShortWatchMilliseconds": 9000,
+      "MaxShortWatchMilliseconds": 18000,
+      "SearchWeight": 0.55,
+      "ShortsWeight": 0.25,
+      "MinDelayBetweenActionsMs": 1800,
+      "MaxDelayBetweenActionsMs": 4200,
+      "Domains": [
+        "https://www.youtube.com",
+        "https://www.youtube.com/feed/explore"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- move GPM and search settings into a new appsettings.json file and bind them to strongly typed options at startup
- create typed profile creation payloads and update the GPM API client to support stop/delete lifecycle calls
- orchestrate Playwright workflow with configuration-driven values and ensure profiles are stopped and deleted in a finally block

## Testing
- dotnet build *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2602a3de48330a87ee6465d4f8216