### PR TITLE
Implement structured YouTube warmup workflow

### DIFF
--- a/Helpers/MouseHelper.cs
+++ b/Helpers/MouseHelper.cs
@@ -17,6 +17,8 @@ namespace GPM_driver.Helpers
         public int MinClickDelay { get; set; } = 120;
         public int MaxClickDelay { get; set; } = 500;
 
+        public IPage Page => _page;
+
         public MouseHelper(IPage page)
         {
             _page = page;

--- a/Services/YouTube/Activities/BaseActivity.cs
+++ b/Services/YouTube/Activities/BaseActivity.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using Microsoft.Extensions.Logging;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal abstract class BaseActivity
+{
+    protected BaseActivity(string name, ILogger logger)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected ILogger Logger { get; }
+
+    internal string Name { get; }
+
+    internal async Task<bool> TryExecuteAsync(WarmupContext context)
+    {
+        try
+        {
+            var result = await ExecuteAsync(context);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Activity {Activity} failed.", Name);
+            return false;
+        }
+    }
+
+    protected abstract Task<bool> ExecuteAsync(WarmupContext context);
+}

--- a/Services/YouTube/Activities/CommentActivity.cs
+++ b/Services/YouTube/Activities/CommentActivity.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class CommentActivity
+{
+    private static readonly string[] Comments =
+    {
+        "Really enjoyed this segment!",
+        "Adding this to my watch later list.",
+        "Great insights, thanks for sharing.",
+        "This was surprisingly helpful!"
+    };
+
+    private readonly ILogger _logger;
+
+    internal CommentActivity(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    internal async Task MaybeCommentAsync(WarmupContext context)
+    {
+        if (context.Random.NextDouble() > 0.05)
+        {
+            return;
+        }
+
+        try
+        {
+            await context.NavigationPattern.RandomScrollAsync(context.Page, context.CancellationToken);
+            var commentBox = context.Page.Locator("ytd-comment-simplebox-renderer #placeholder-area").First;
+            if (!await commentBox.IsVisibleAsync(new() { Timeout = 3000 }))
+            {
+                return;
+            }
+
+            await commentBox.ClickAsync();
+            var input = context.Page.Locator("ytd-comment-dialog-renderer #contenteditable-root, #contenteditable-root[contenteditable]").First;
+            if (!await input.IsVisibleAsync(new() { Timeout = 2000 }))
+            {
+                return;
+            }
+
+            var message = Comments[context.Random.Next(Comments.Length)];
+            await input.TypeAsync(message, new() { Delay = context.Random.Next(40, 120) });
+            await context.TimingPattern.PauseAsync(context.Random.Next(500, 1200), context.CancellationToken);
+            await context.Page.Keyboard.PressAsync("Escape");
+            context.ActivityLog.Add("Drafted a comment");
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger.LogDebug(ex, "Failed to draft comment during warmup.");
+        }
+    }
+}

--- a/Services/YouTube/Activities/HomeActivity.cs
+++ b/Services/YouTube/Activities/HomeActivity.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using GPM_driver.Services.YouTube.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class HomeActivity : BaseActivity
+{
+    private readonly VideoPlayerActivity _videoPlayer;
+
+    internal HomeActivity(ILogger logger, VideoPlayerActivity videoPlayer)
+        : base(YouTubeWarmupBehavior.Home, logger)
+    {
+        _videoPlayer = videoPlayer;
+    }
+
+    protected override async Task<bool> ExecuteAsync(WarmupContext context)
+    {
+        var url = context.NavigationPattern.GetHomeUrl();
+        await context.Page.GotoAsync(url, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 60000 });
+        await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+        await context.NavigationPattern.RandomScrollAsync(context.Page, context.CancellationToken);
+        context.ActivityLog.Add($"Browsed home feed at {context.Page.Url}");
+
+        var videos = context.Page.Locator("ytd-rich-item-renderer a#video-title-link, ytd-rich-grid-media a#video-title-link");
+        var count = await videos.CountAsync();
+        if (count == 0)
+        {
+            return true;
+        }
+
+        var index = context.Random.Next(Math.Min(count, 6));
+        var target = videos.Nth(index);
+        string? href = null;
+
+        try
+        {
+            href = await target.GetAttributeAsync("href");
+            await target.ScrollIntoViewIfNeededAsync();
+            await target.ClickAsync(new() { Delay = context.Random.Next(40, 120) });
+            await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+        }
+        catch (PlaywrightException ex)
+        {
+            Logger.LogDebug(ex, "Failed to open home video suggestion.");
+            return true;
+        }
+
+        return await _videoPlayer.WatchCurrentVideoAsync(context, href ?? "home");
+    }
+}

--- a/Services/YouTube/Activities/LikeDislikeActivity.cs
+++ b/Services/YouTube/Activities/LikeDislikeActivity.cs
@@ -1,0 +1,66 @@
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class LikeDislikeActivity
+{
+    private readonly ILogger _logger;
+
+    internal LikeDislikeActivity(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    internal async Task MaybeLikeAsync(WarmupContext context)
+    {
+        if (context.Random.NextDouble() > 0.35)
+        {
+            return;
+        }
+
+        try
+        {
+            var likeButton = context.Page.Locator("ytd-toggle-button-renderer#like-button button").First;
+            if (!await likeButton.IsVisibleAsync(new() { Timeout = 2000 }))
+            {
+                return;
+            }
+
+            await likeButton.HoverAsync();
+            await likeButton.ClickAsync(new() { Delay = context.Random.Next(40, 140) });
+            context.ActivityLog.Add("Left a like on video");
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger.LogDebug(ex, "Failed to like video during warmup.");
+        }
+    }
+
+    internal async Task MaybeDislikeAsync(WarmupContext context)
+    {
+        if (context.Random.NextDouble() > 0.05)
+        {
+            return;
+        }
+
+        try
+        {
+            var dislikeButton = context.Page.Locator("ytd-toggle-button-renderer#dislike-button button").First;
+            if (!await dislikeButton.IsVisibleAsync(new() { Timeout = 2000 }))
+            {
+                return;
+            }
+
+            await dislikeButton.ClickAsync(new() { Delay = context.Random.Next(40, 140) });
+            context.ActivityLog.Add("Left a dislike on video");
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger.LogDebug(ex, "Failed to dislike video during warmup.");
+        }
+    }
+}

--- a/Services/YouTube/Activities/RecommendationActivity.cs
+++ b/Services/YouTube/Activities/RecommendationActivity.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+
+using GPM_driver.Helpers;
+using GPM_driver.Services.YouTube.Core;
+using GPM_driver.Services.YouTube.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class RecommendationActivity : BaseActivity
+{
+    private readonly VideoPlayerActivity _videoPlayer;
+
+    internal RecommendationActivity(ILogger logger, VideoPlayerActivity videoPlayer)
+        : base(YouTubeWarmupBehavior.Recommendations, logger)
+    {
+        _videoPlayer = videoPlayer;
+    }
+
+    protected override async Task<bool> ExecuteAsync(WarmupContext context)
+    {
+        if (YouTubeUrlHelper.GetVideoKind(context.Page.Url) != YouTubeUrlHelper.YouTubeVideoKind.Video)
+        {
+            return false;
+        }
+
+        var recommendations = context.Page.Locator("#secondary ytd-compact-video-renderer a#thumbnail");
+        var available = await recommendations.CountAsync();
+        if (available == 0)
+        {
+            return false;
+        }
+
+        var targetIndex = context.Random.Next(available);
+        var target = recommendations.Nth(targetIndex);
+        string? href = null;
+        try
+        {
+            href = await target.GetAttributeAsync("href");
+            await target.ScrollIntoViewIfNeededAsync();
+            await target.ClickAsync(new() { Delay = context.Random.Next(30, 100) });
+            await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+        }
+        catch (PlaywrightException ex)
+        {
+            Logger.LogDebug(ex, "Failed to open recommendation.");
+            return false;
+        }
+
+        return await _videoPlayer.WatchCurrentVideoAsync(context, href ?? "recommendation");
+    }
+}

--- a/Services/YouTube/Activities/SearchActivity.cs
+++ b/Services/YouTube/Activities/SearchActivity.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using GPM_driver.Services.YouTube.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class SearchActivity : BaseActivity
+{
+    private readonly VideoPlayerActivity _videoPlayer;
+
+    internal SearchActivity(ILogger logger, VideoPlayerActivity videoPlayer)
+        : base(YouTubeWarmupBehavior.Search, logger)
+    {
+        _videoPlayer = videoPlayer;
+    }
+
+    protected override async Task<bool> ExecuteAsync(WarmupContext context)
+    {
+        var keyword = context.Configuration.GetRandomKeyword(context.Random);
+        var baseUrl = context.NavigationPattern.GetHomeUrl();
+        if (!baseUrl.EndsWith("/", StringComparison.Ordinal))
+        {
+            baseUrl += "/";
+        }
+
+        var searchUrl = baseUrl + "results?search_query=" + Uri.EscapeDataString(keyword);
+        await context.Page.GotoAsync(searchUrl, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 60000 });
+        await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+
+        var results = context.Page.Locator("ytd-video-renderer a#video-title");
+        var count = await results.CountAsync();
+        if (count == 0)
+        {
+            return false;
+        }
+
+        var targetIndex = context.Random.Next(Math.Min(count, 5));
+        var target = results.Nth(targetIndex);
+
+        string? href = null;
+        try
+        {
+            href = await target.GetAttributeAsync("href");
+            await target.ScrollIntoViewIfNeededAsync();
+            await target.ClickAsync(new() { Delay = context.Random.Next(50, 150) });
+            await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+        }
+        catch (PlaywrightException ex)
+        {
+            Logger.LogDebug(ex, "Failed to open search result for keyword {Keyword}.", keyword);
+            return false;
+        }
+
+        context.ActivityLog.Add($"Searched for '{keyword}'");
+        return await _videoPlayer.WatchCurrentVideoAsync(context, href ?? keyword);
+    }
+}

--- a/Services/YouTube/Activities/ShareActivity.cs
+++ b/Services/YouTube/Activities/ShareActivity.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class ShareActivity
+{
+    private readonly ILogger _logger;
+
+    internal ShareActivity(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    internal async Task MaybeShareAsync(WarmupContext context)
+    {
+        if (context.Random.NextDouble() > 0.1)
+        {
+            return;
+        }
+
+        try
+        {
+            var shareButton = context.Page.Locator("ytd-button-renderer#share-button button").First;
+            if (!await shareButton.IsVisibleAsync(new() { Timeout = 2000 }))
+            {
+                return;
+            }
+
+            await shareButton.ClickAsync(new() { Delay = context.Random.Next(40, 120) });
+            await context.TimingPattern.PauseAsync(context.Random.Next(1200, 2200), context.CancellationToken);
+            var closeButton = context.Page.Locator("ytd-share-sheet-renderer tp-yt-icon-button[aria-label]").First;
+            if (await closeButton.IsVisibleAsync(new() { Timeout = 1000 }))
+            {
+                await closeButton.ClickAsync();
+            }
+
+            context.ActivityLog.Add("Opened share dialog");
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger.LogDebug(ex, "Failed to share during warmup.");
+        }
+    }
+}

--- a/Services/YouTube/Activities/ShortsActivity.cs
+++ b/Services/YouTube/Activities/ShortsActivity.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using GPM_driver.Services.YouTube.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class ShortsActivity : BaseActivity
+{
+    internal ShortsActivity(ILogger logger)
+        : base(YouTubeWarmupBehavior.Shorts, logger)
+    {
+    }
+
+    protected override async Task<bool> ExecuteAsync(WarmupContext context)
+    {
+        var baseUrl = context.NavigationPattern.GetHomeUrl();
+        if (!baseUrl.EndsWith("/"))
+        {
+            baseUrl += "/";
+        }
+
+        await context.Page.GotoAsync(baseUrl + "shorts", new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60000 });
+        await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+
+        int sequenceLength = context.TimingPattern.NextBetween(
+            context.Configuration.Settings.MinShortSequenceLength,
+            context.Configuration.Settings.MaxShortSequenceLength);
+
+        for (int i = 0; i < sequenceLength; i++)
+        {
+            await context.DetectionAvoidance.RandomMouseJitterAsync(context.Mouse, context.CancellationToken);
+            var watchTime = context.TimingPattern.NextBetween(
+                context.Configuration.Settings.MinShortWatchMilliseconds,
+                context.Configuration.Settings.MaxShortWatchMilliseconds);
+            await context.TimingPattern.PauseAsync(watchTime, context.CancellationToken);
+            context.ActivityLog.Add($"Watched short #{i + 1} for {watchTime}ms");
+
+            if (i + 1 < sequenceLength)
+            {
+                await context.NavigationPattern.TryPressAsync(context.Page, "ArrowDown", context.CancellationToken);
+            }
+        }
+
+        return true;
+    }
+}

--- a/Services/YouTube/Activities/SubscribeActivity.cs
+++ b/Services/YouTube/Activities/SubscribeActivity.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class SubscribeActivity
+{
+    private readonly ILogger _logger;
+
+    internal SubscribeActivity(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    internal async Task MaybeSubscribeAsync(WarmupContext context)
+    {
+        if (context.Random.NextDouble() > 0.25)
+        {
+            return;
+        }
+
+        try
+        {
+            var subscribeButton = context.Page.Locator("#subscribe-button ytd-subscribe-button-renderer tp-yt-paper-button, #subscribe-button button").First;
+            if (!await subscribeButton.IsVisibleAsync(new() { Timeout = 2000 }))
+            {
+                return;
+            }
+
+            var label = await subscribeButton.GetAttributeAsync("aria-pressed");
+            if (string.Equals(label, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            await subscribeButton.ClickAsync(new() { Delay = context.Random.Next(40, 120) });
+            context.ActivityLog.Add("Subscribed to channel");
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger.LogDebug(ex, "Failed to subscribe during warmup.");
+        }
+    }
+}

--- a/Services/YouTube/Activities/VideoPlayerActivity.cs
+++ b/Services/YouTube/Activities/VideoPlayerActivity.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+internal sealed class VideoPlayerActivity
+{
+    private readonly ILogger _logger;
+    private readonly LikeDislikeActivity _likeDislike;
+    private readonly SubscribeActivity _subscribe;
+    private readonly ShareActivity _share;
+    private readonly CommentActivity _comment;
+
+    internal VideoPlayerActivity(
+        ILogger logger,
+        LikeDislikeActivity likeDislike,
+        SubscribeActivity subscribe,
+        ShareActivity share,
+        CommentActivity comment)
+    {
+        _logger = logger;
+        _likeDislike = likeDislike;
+        _subscribe = subscribe;
+        _share = share;
+        _comment = comment;
+    }
+
+    internal async Task<bool> WatchCurrentVideoAsync(WarmupContext context, string origin)
+    {
+        try
+        {
+            await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+            var video = context.Page.Locator("video.html5-main-video").First;
+            await video.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 45000 });
+
+            // Ensure playback
+            await context.Page.Keyboard.PressAsync("k");
+            await context.DetectionAvoidance.SmallPauseAsync(context.CancellationToken);
+
+            var totalWatch = context.TimingPattern.NextBetween(
+                context.Configuration.Settings.MinWatchMilliseconds,
+                context.Configuration.Settings.MaxWatchMilliseconds);
+
+            int segments = context.Random.Next(2, 4);
+            for (int i = 0; i < segments; i++)
+            {
+                await context.DetectionAvoidance.RandomMouseJitterAsync(context.Mouse, context.CancellationToken);
+                var segmentDuration = totalWatch / segments;
+                segmentDuration = Math.Clamp(segmentDuration, 2000, context.Configuration.Settings.MaxWatchMilliseconds);
+                await context.TimingPattern.PauseAsync(segmentDuration, context.CancellationToken);
+                if (i == 0)
+                {
+                    await _likeDislike.MaybeLikeAsync(context);
+                }
+            }
+
+            await _likeDislike.MaybeDislikeAsync(context);
+            await _subscribe.MaybeSubscribeAsync(context);
+            await _share.MaybeShareAsync(context);
+            await _comment.MaybeCommentAsync(context);
+
+            context.ActivityLog.Add($"Watched video from {origin} for {totalWatch}ms");
+
+            if (context.Random.NextDouble() < context.Configuration.Settings.AutoplayFollowProbability)
+            {
+                var nextButton = context.Page.Locator("button[aria-label*='Next'], a.ytp-next-button").First;
+                if (await nextButton.IsVisibleAsync(new() { Timeout = 2000 }))
+                {
+                    await nextButton.ClickAsync(new() { Delay = context.Random.Next(30, 110) });
+                    await context.NavigationPattern.EnsureVisibleAsync(context.Page, context.CancellationToken);
+                    context.ActivityLog.Add("Followed autoplay to next video");
+                }
+            }
+
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger.LogDebug(ex, "Failed to watch video during warmup.");
+            return false;
+        }
+    }
+}

--- a/Services/YouTube/Core/ConfigManager.cs
+++ b/Services/YouTube/Core/ConfigManager.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using GPM_driver.Models;
+using GPM_driver.Services.YouTube.Data;
+using Microsoft.Extensions.Logging;
+
+namespace GPM_driver.Services.YouTube.Core;
+
+internal sealed class ConfigManager
+{
+    private readonly ILogger _logger;
+    private readonly Random _random;
+
+    internal ConfigManager(ILogger logger, Random random)
+    {
+        _logger = logger;
+        _random = random;
+    }
+
+    internal async Task<YouTubeWarmupConfiguration> LoadAsync(
+        string? keywordDirectory,
+        YouTubeWarmupSettings settings,
+        string? profileId,
+        CancellationToken cancellationToken)
+    {
+        var persona = UserProfiles.ResolvePersona(settings.Persona);
+        var keywords = await LoadKeywordsAsync(keywordDirectory, persona, cancellationToken);
+        var behaviors = settings.Behaviors?.Length > 0 ? settings.Behaviors : new[] { YouTubeWarmupBehavior.Search, YouTubeWarmupBehavior.Home };
+        var domain = ResolveDomain(settings);
+
+        var configuration = new YouTubeWarmupConfiguration(
+            settings,
+            persona,
+            keywords,
+            behaviors,
+            domain);
+
+        await CacheIdentityAsync(configuration, settings, profileId, cancellationToken);
+        return configuration;
+    }
+
+    private async Task<IReadOnlyCollection<string>> LoadKeywordsAsync(
+        string? keywordDirectory,
+        YouTubePersona persona,
+        CancellationToken cancellationToken)
+    {
+        var keywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(keywordDirectory) && Directory.Exists(keywordDirectory))
+        {
+            foreach (var file in Directory.EnumerateFiles(keywordDirectory, "*.txt", SearchOption.AllDirectories))
+            {
+                await foreach (var keyword in ReadKeywordsAsync(file, cancellationToken))
+                {
+                    keywords.Add(keyword);
+                }
+            }
+        }
+
+        if (keywords.Count == 0)
+        {
+            foreach (var keyword in persona.PrimaryInterests.Concat(persona.SecondaryInterests))
+            {
+                keywords.Add(keyword);
+            }
+        }
+
+        return keywords.ToArray();
+    }
+
+    private static async IAsyncEnumerable<string> ReadKeywordsAsync(string path, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        using var reader = new StreamReader(stream);
+        while (!reader.EndOfStream)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var line = await reader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            yield return line.Trim();
+        }
+    }
+
+    private static string ResolveDomain(YouTubeWarmupSettings settings)
+    {
+        var domains = settings.Domains ?? Array.Empty<string>();
+        if (domains.Length == 0)
+        {
+            return "https://www.youtube.com";
+        }
+
+        return domains[0];
+    }
+
+    private async Task CacheIdentityAsync(
+        YouTubeWarmupConfiguration configuration,
+        YouTubeWarmupSettings settings,
+        string? profileId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(settings.IdentityCacheDirectory))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(settings.IdentityCacheDirectory);
+            var safeProfile = string.IsNullOrWhiteSpace(profileId) ? "default" : profileId;
+            var path = Path.Combine(settings.IdentityCacheDirectory, $"{safeProfile}.json");
+            var cache = new IdentityCache
+            {
+                Persona = configuration.Persona.Name,
+                LastKeywords = configuration.Keywords.OrderBy(_ => _random.Next()).Take(settings.IdentityKeywordFileCount).ToArray(),
+                Timestamp = DateTimeOffset.UtcNow
+            };
+
+            await using var stream = File.Create(path);
+            await JsonSerializer.SerializeAsync(stream, cache, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to persist YouTube warmup identity cache.");
+        }
+    }
+
+    private sealed record IdentityCache
+    {
+        public string Persona { get; init; } = string.Empty;
+        public string[] LastKeywords { get; init; } = Array.Empty<string>();
+        public DateTimeOffset Timestamp { get; init; }
+    }
+}

--- a/Services/YouTube/Core/SessionManager.cs
+++ b/Services/YouTube/Core/SessionManager.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Core;
+
+internal sealed class SessionManager
+{
+    private readonly IBrowserContext _context;
+    private readonly ILogger _logger;
+
+    internal SessionManager(IBrowserContext context, ILogger logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    internal async Task<IPage> EnsurePageAsync(CancellationToken cancellationToken)
+    {
+        var page = _context.Pages.FirstOrDefault(p => !p.IsClosed);
+        if (page != null)
+        {
+            return page;
+        }
+
+        _logger.LogDebug("No available page, opening dedicated YouTube warmup tab.");
+        page = await _context.NewPageAsync();
+        await page.SetViewportSizeAsync(1280, 720);
+        return page;
+    }
+}

--- a/Services/YouTube/Core/WarmupContext.cs
+++ b/Services/YouTube/Core/WarmupContext.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+
+using GPM_driver.Helpers;
+using GPM_driver.Services.YouTube.Data;
+using GPM_driver.Services.YouTube.Patterns;
+using GPM_driver.Services.YouTube.Safety;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Core;
+
+internal sealed class WarmupContext
+{
+    internal WarmupContext(
+        IBrowserContext browserContext,
+        IPage page,
+        MouseHelper mouse,
+        KeyboardHelper keyboard,
+        YouTubeWarmupConfiguration configuration,
+        ActivityLog activityLog,
+        TimingPattern timingPattern,
+        BehaviorPattern behaviorPattern,
+        NavigationPattern navigationPattern,
+        RateLimiter rateLimiter,
+        DetectionAvoidance detectionAvoidance,
+        Random random,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        BrowserContext = browserContext ?? throw new ArgumentNullException(nameof(browserContext));
+        Page = page ?? throw new ArgumentNullException(nameof(page));
+        Mouse = mouse ?? throw new ArgumentNullException(nameof(mouse));
+        Keyboard = keyboard ?? throw new ArgumentNullException(nameof(keyboard));
+        Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        ActivityLog = activityLog ?? throw new ArgumentNullException(nameof(activityLog));
+        TimingPattern = timingPattern ?? throw new ArgumentNullException(nameof(timingPattern));
+        BehaviorPattern = behaviorPattern ?? throw new ArgumentNullException(nameof(behaviorPattern));
+        NavigationPattern = navigationPattern ?? throw new ArgumentNullException(nameof(navigationPattern));
+        RateLimiter = rateLimiter ?? throw new ArgumentNullException(nameof(rateLimiter));
+        DetectionAvoidance = detectionAvoidance ?? throw new ArgumentNullException(nameof(detectionAvoidance));
+        Random = random ?? throw new ArgumentNullException(nameof(random));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        CancellationToken = cancellationToken;
+    }
+
+    internal IBrowserContext BrowserContext { get; }
+
+    internal IPage Page { get; }
+
+    internal MouseHelper Mouse { get; }
+
+    internal KeyboardHelper Keyboard { get; }
+
+    internal YouTubeWarmupConfiguration Configuration { get; }
+
+    internal ActivityLog ActivityLog { get; }
+
+    internal TimingPattern TimingPattern { get; }
+
+    internal BehaviorPattern BehaviorPattern { get; }
+
+    internal NavigationPattern NavigationPattern { get; }
+
+    internal RateLimiter RateLimiter { get; }
+
+    internal DetectionAvoidance DetectionAvoidance { get; }
+
+    internal Random Random { get; }
+
+    internal ILogger Logger { get; }
+
+    internal CancellationToken CancellationToken { get; }
+}

--- a/Services/YouTube/Core/WarmupManager.cs
+++ b/Services/YouTube/Core/WarmupManager.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using GPM_driver.Services.YouTube.Activities;
+using GPM_driver.Services.YouTube.Data;
+
+namespace GPM_driver.Services.YouTube.Core;
+
+internal sealed class WarmupManager
+{
+    private readonly WarmupContext _context;
+    private readonly IDictionary<string, BaseActivity> _activities;
+    private readonly Random _random;
+
+    internal WarmupManager(WarmupContext context, IEnumerable<BaseActivity> activities, Random random)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _random = random ?? throw new ArgumentNullException(nameof(random));
+        _activities = new Dictionary<string, BaseActivity>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var activity in activities)
+        {
+            _activities[activity.Name] = activity;
+        }
+    }
+
+    internal async Task RunAsync()
+    {
+        var settings = _context.Configuration.Settings;
+        int plannedInteractions = _random.Next(settings.MinInteractions, settings.MaxInteractions + 1);
+        int executedInteractions = 0;
+
+        while (executedInteractions < plannedInteractions)
+        {
+            _context.CancellationToken.ThrowIfCancellationRequested();
+            await _context.RateLimiter.WaitForTurnAsync(settings.MinDelayBetweenActionsMs, settings.MaxDelayBetweenActionsMs, _context.CancellationToken);
+
+            var behavior = _context.BehaviorPattern.ChooseBehavior(_context.Configuration.Behaviors, settings);
+            if (!_activities.TryGetValue(behavior, out var activity))
+            {
+                _context.Logger.LogDebug("No YouTube warmup activity mapped for behavior {Behavior}.", behavior);
+                return;
+            }
+
+            bool executed = await activity.TryExecuteAsync(_context);
+            if (!executed)
+            {
+                _context.Logger.LogDebug("YouTube warmup activity {Activity} did not complete successfully.", activity.Name);
+            }
+            else
+            {
+                executedInteractions++;
+            }
+
+            if (executedInteractions >= settings.MaxInteractions)
+            {
+                break;
+            }
+
+            if (_random.NextDouble() > settings.ContinueProbability)
+            {
+                break;
+            }
+        }
+
+        _context.Logger.LogInformation("Completed {Count} YouTube warmup interactions.", executedInteractions);
+    }
+}

--- a/Services/YouTube/Data/ActivityLog.cs
+++ b/Services/YouTube/Data/ActivityLog.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace GPM_driver.Services.YouTube.Data;
+
+internal sealed class ActivityLog
+{
+    private readonly ConcurrentQueue<string> _entries = new();
+
+    internal void Add(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        _entries.Enqueue(message);
+        while (_entries.Count > 100)
+        {
+            _entries.TryDequeue(out _);
+        }
+    }
+
+    internal IReadOnlyCollection<string> Snapshot()
+    {
+        return _entries.ToArray();
+    }
+}

--- a/Services/YouTube/Data/UserProfiles.cs
+++ b/Services/YouTube/Data/UserProfiles.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GPM_driver.Services.YouTube.Data;
+
+internal static class UserProfiles
+{
+    private static readonly IReadOnlyDictionary<string, YouTubePersona> Personas =
+        new Dictionary<string, YouTubePersona>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Generalist"] = new(
+                "Generalist",
+                new[]
+                {
+                    "latest news",
+                    "technology reviews",
+                    "travel vlogs",
+                    "music videos",
+                    "productivity tips"
+                },
+                new[]
+                {
+                    "gaming highlights",
+                    "movie trailers",
+                    "podcast clips",
+                    "cooking recipes"
+                }),
+            ["Creator"] = new(
+                "Creator",
+                new[]
+                {
+                    "content creation tips",
+                    "video editing tutorials",
+                    "camera gear reviews",
+                    "productivity workflows"
+                },
+                new[]
+                {
+                    "vlog inspiration",
+                    "social media strategy",
+                    "motion graphics"
+                }),
+            ["Gamer"] = new(
+                "Gamer",
+                new[]
+                {
+                    "game walkthrough",
+                    "esports highlights",
+                    "speedrun",
+                    "game review"
+                },
+                new[]
+                {
+                    "game soundtrack",
+                    "gaming news",
+                    "mod showcase"
+                }),
+            ["Learner"] = new(
+                "Learner",
+                new[]
+                {
+                    "programming tutorial",
+                    "math lecture",
+                    "science documentary",
+                    "history explained"
+                },
+                new[]
+                {
+                    "study music",
+                    "note taking tips",
+                    "learning strategies"
+                })
+        };
+
+    internal static YouTubePersona ResolvePersona(string? personaName)
+    {
+        if (string.IsNullOrWhiteSpace(personaName))
+        {
+            return Personas["Generalist"];
+        }
+
+        if (Personas.TryGetValue(personaName, out var persona))
+        {
+            return persona;
+        }
+
+        return Personas.Values.First();
+    }
+}
+
+internal sealed record YouTubePersona(
+    string Name,
+    IReadOnlyList<string> PrimaryInterests,
+    IReadOnlyList<string> SecondaryInterests);

--- a/Services/YouTube/Data/WarmupConfig.cs
+++ b/Services/YouTube/Data/WarmupConfig.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+using GPM_driver.Models;
+
+namespace GPM_driver.Services.YouTube.Data;
+
+internal sealed class YouTubeWarmupConfiguration
+{
+    internal YouTubeWarmupConfiguration(
+        YouTubeWarmupSettings settings,
+        YouTubePersona persona,
+        IReadOnlyCollection<string> keywords,
+        IReadOnlyCollection<string> behaviors,
+        string startDomain)
+    {
+        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        Persona = persona ?? throw new ArgumentNullException(nameof(persona));
+        Keywords = new ReadOnlyCollection<string>(keywords?.ToArray() ?? Array.Empty<string>());
+        Behaviors = new ReadOnlyCollection<string>(behaviors?.ToArray() ?? Array.Empty<string>());
+        StartDomain = startDomain;
+    }
+
+    internal YouTubeWarmupSettings Settings { get; }
+
+    internal YouTubePersona Persona { get; }
+
+    internal IReadOnlyList<string> Keywords { get; }
+
+    internal IReadOnlyList<string> Behaviors { get; }
+
+    internal string StartDomain { get; }
+
+    internal string GetRandomKeyword(Random random)
+    {
+        if (Keywords.Count == 0)
+        {
+            return "popular videos";
+        }
+
+        var index = random.Next(Keywords.Count);
+        return Keywords[index];
+    }
+}
+
+internal static class YouTubeWarmupBehavior
+{
+    internal const string Search = "Search";
+    internal const string Home = "Home";
+    internal const string Shorts = "Shorts";
+    internal const string Recommendations = "Recommendations";
+}

--- a/Services/YouTube/Patterns/BehaviorPattern.cs
+++ b/Services/YouTube/Patterns/BehaviorPattern.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GPM_driver.Services.YouTube.Data;
+
+namespace GPM_driver.Services.YouTube.Patterns;
+
+internal sealed class BehaviorPattern
+{
+    private readonly Random _random;
+
+    internal BehaviorPattern(Random random)
+    {
+        _random = random;
+    }
+
+    internal string ChooseBehavior(IReadOnlyList<string> behaviors, YouTubeWarmupSettings settings)
+    {
+        if (behaviors == null || behaviors.Count == 0)
+        {
+            return YouTubeWarmupBehavior.Search;
+        }
+
+        var weights = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
+        {
+            [YouTubeWarmupBehavior.Search] = Math.Max(settings.SearchWeight, 0.01),
+            [YouTubeWarmupBehavior.Shorts] = Math.Max(settings.ShortsWeight, 0.01),
+            [YouTubeWarmupBehavior.Home] = 1.0,
+            [YouTubeWarmupBehavior.Recommendations] = Math.Max(settings.RecommendationChainProbability, 0.1)
+        };
+
+        var filtered = behaviors.Where(b => weights.ContainsKey(b)).ToArray();
+        if (filtered.Length == 0)
+        {
+            return behaviors[_random.Next(behaviors.Count)];
+        }
+
+        double total = filtered.Sum(b => weights[b]);
+        var roll = _random.NextDouble() * total;
+        double cumulative = 0;
+        foreach (var behavior in filtered)
+        {
+            cumulative += weights[behavior];
+            if (roll <= cumulative)
+            {
+                return behavior;
+            }
+        }
+
+        return filtered.Last();
+    }
+}

--- a/Services/YouTube/Patterns/NavigationPattern.cs
+++ b/Services/YouTube/Patterns/NavigationPattern.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Patterns;
+
+internal sealed class NavigationPattern
+{
+    private readonly Random _random;
+    private readonly string[] _domains;
+
+    internal NavigationPattern(Random random, string[] domains)
+    {
+        _random = random;
+        _domains = domains.Length == 0
+            ? new[] { "https://www.youtube.com" }
+            : domains;
+    }
+
+    internal string GetHomeUrl()
+    {
+        var domain = _domains[_random.Next(_domains.Length)];
+        return domain.EndsWith("/", StringComparison.Ordinal) ? domain : domain + "/";
+    }
+
+    internal async Task EnsureVisibleAsync(IPage page, CancellationToken cancellationToken)
+    {
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 60000 });
+        await Task.Delay(_random.Next(500, 1500), cancellationToken);
+    }
+
+    internal async Task RandomScrollAsync(IPage page, CancellationToken cancellationToken)
+    {
+        var scrollSteps = _random.Next(2, 6);
+        for (int i = 0; i < scrollSteps; i++)
+        {
+            int scrollBy = _random.Next(500, 1200);
+            await page.EvaluateAsync(
+                "window.scrollBy(0, arguments[0]);",
+                scrollBy);
+            await Task.Delay(_random.Next(500, 2000), cancellationToken);
+        }
+    }
+
+    internal async Task<bool> TryClickAsync(IPage page, string selector, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var locator = page.Locator(selector).First;
+            if (await locator.IsVisibleAsync(new() { Timeout = 2000 }) && await locator.IsEnabledAsync())
+            {
+                await locator.ClickAsync(new() { Delay = _random.Next(50, 150) });
+                await Task.Delay(_random.Next(300, 900), cancellationToken);
+                return true;
+            }
+        }
+        catch (PlaywrightException)
+        {
+        }
+
+        return false;
+    }
+
+    internal async Task<bool> TryPressAsync(IPage page, string key, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await page.Keyboard.PressAsync(key);
+            await Task.Delay(_random.Next(200, 600), cancellationToken);
+            return true;
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
+    }
+}

--- a/Services/YouTube/Patterns/TimingPattern.cs
+++ b/Services/YouTube/Patterns/TimingPattern.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GPM_driver.Services.YouTube.Patterns;
+
+internal sealed class TimingPattern
+{
+    private readonly Random _random;
+
+    internal TimingPattern(Random random)
+    {
+        _random = random;
+    }
+
+    internal Task DelayBetweenActionsAsync(int minMilliseconds, int maxMilliseconds, CancellationToken cancellationToken)
+    {
+        var nextDelay = NextBetween(minMilliseconds, maxMilliseconds);
+        return Task.Delay(nextDelay, cancellationToken);
+    }
+
+    internal Task PauseAsync(int milliseconds, CancellationToken cancellationToken)
+    {
+        if (milliseconds <= 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        return Task.Delay(milliseconds, cancellationToken);
+    }
+
+    internal int NextBetween(int minMilliseconds, int maxMilliseconds)
+    {
+        if (minMilliseconds < 0)
+        {
+            minMilliseconds = 0;
+        }
+
+        if (maxMilliseconds < minMilliseconds)
+        {
+            maxMilliseconds = minMilliseconds + 1;
+        }
+
+        return _random.Next(minMilliseconds, maxMilliseconds + 1);
+    }
+}

--- a/Services/YouTube/Safety/DetectionAvoidance.cs
+++ b/Services/YouTube/Safety/DetectionAvoidance.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using GPM_driver.Helpers;
+
+namespace GPM_driver.Services.YouTube.Safety;
+
+internal sealed class DetectionAvoidance
+{
+    private readonly Random _random;
+
+    internal DetectionAvoidance(Random random)
+    {
+        _random = random;
+    }
+
+    internal async Task RandomMouseJitterAsync(MouseHelper mouse, CancellationToken cancellationToken)
+    {
+        if (mouse == null)
+        {
+            return;
+        }
+
+        var jitterCount = _random.Next(1, 3);
+        for (int i = 0; i < jitterCount; i++)
+        {
+            var viewport = mouse.Page.ViewportSize;
+            int width = viewport?.Width ?? 1280;
+            int height = viewport?.Height ?? 720;
+            var x = _random.Next(width / 4, width - width / 4);
+            var y = _random.Next(height / 4, height - height / 4);
+            await mouse.MoveAsync(x, y, steps: _random.Next(8, 15));
+            await Task.Delay(_random.Next(120, 260), cancellationToken);
+        }
+    }
+
+    internal Task SmallPauseAsync(CancellationToken cancellationToken)
+    {
+        return Task.Delay(_random.Next(350, 900), cancellationToken);
+    }
+}

--- a/Services/YouTube/Safety/ErrorHandler.cs
+++ b/Services/YouTube/Safety/ErrorHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+namespace GPM_driver.Services.YouTube.Safety;
+
+internal static class ErrorHandler
+{
+    internal static async Task<bool> RunSafeAsync(Func<Task> action, ILogger logger, string scope)
+    {
+        try
+        {
+            await action();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "YouTube warmup step '{Scope}' failed.", scope);
+            return false;
+        }
+    }
+}

--- a/Services/YouTube/Safety/RateLimiter.cs
+++ b/Services/YouTube/Safety/RateLimiter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GPM_driver.Services.YouTube.Safety;
+
+internal sealed class RateLimiter
+{
+    private readonly Random _random;
+    private DateTime _nextAllowedAction = DateTime.UtcNow;
+
+    internal RateLimiter(Random random)
+    {
+        _random = random;
+    }
+
+    internal async Task WaitForTurnAsync(int minDelayMs, int maxDelayMs, CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        if (now < _nextAllowedAction)
+        {
+            var wait = _nextAllowedAction - now;
+            if (wait > TimeSpan.Zero)
+            {
+                await Task.Delay(wait, cancellationToken);
+            }
+        }
+
+        var delay = _random.Next(minDelayMs, maxDelayMs + 1);
+        _nextAllowedAction = DateTime.UtcNow.AddMilliseconds(delay);
+    }
+}

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -1,13 +1,15 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
-using GPM_driver.Services.YouTube;
+using GPM_driver.Services.YouTube.Activities;
+using GPM_driver.Services.YouTube.Core;
+using GPM_driver.Services.YouTube.Data;
+using GPM_driver.Services.YouTube.Patterns;
+using GPM_driver.Services.YouTube.Safety;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Playwright;
 
 namespace GPM_driver.Services;
@@ -27,5 +29,91 @@ internal class YouTubeWarmupService
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _logger = logger;
+    }
+
+    public async Task RunWarmupAsync(
+        string? keywordDirectory,
+        YouTubeWarmupSettings settings,
+        string? profileId,
+        CancellationToken cancellationToken = default)
+    {
+        if (settings == null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        if (settings.MinInteractions < 1)
+        {
+            settings.MinInteractions = 1;
+        }
+
+        if (settings.MaxInteractions < settings.MinInteractions)
+        {
+            settings.MaxInteractions = settings.MinInteractions;
+        }
+
+        if (settings.MinDelayBetweenActionsMs < 500)
+        {
+            settings.MinDelayBetweenActionsMs = 500;
+        }
+
+        if (settings.MaxDelayBetweenActionsMs < settings.MinDelayBetweenActionsMs)
+        {
+            settings.MaxDelayBetweenActionsMs = settings.MinDelayBetweenActionsMs + 500;
+        }
+
+        var logger = (ILogger)_logger ?? NullLogger<YouTubeWarmupService>.Instance;
+        var sessionManager = new SessionManager(_context, logger);
+        _page = await sessionManager.EnsurePageAsync(cancellationToken);
+        _mouseHelper = new MouseHelper(_page);
+        _keyboardHelper = new KeyboardHelper(_page);
+
+        var timingPattern = new TimingPattern(_random);
+        var behaviorPattern = new BehaviorPattern(_random);
+        var navigationPattern = new NavigationPattern(_random, settings.Domains ?? Array.Empty<string>());
+        var rateLimiter = new RateLimiter(_random);
+        var detectionAvoidance = new DetectionAvoidance(_random);
+        var activityLog = new ActivityLog();
+        var configManager = new ConfigManager(logger, _random);
+        var configuration = await configManager.LoadAsync(keywordDirectory, settings, profileId, cancellationToken);
+
+        var context = new WarmupContext(
+            _context,
+            _page,
+            _mouseHelper,
+            _keyboardHelper,
+            configuration,
+            activityLog,
+            timingPattern,
+            behaviorPattern,
+            navigationPattern,
+            rateLimiter,
+            detectionAvoidance,
+            _random,
+            logger,
+            cancellationToken);
+
+        var likeDislike = new LikeDislikeActivity(logger);
+        var subscribe = new SubscribeActivity(logger);
+        var share = new ShareActivity(logger);
+        var comment = new CommentActivity(logger);
+        var videoPlayer = new VideoPlayerActivity(logger, likeDislike, subscribe, share, comment);
+
+        var activities = new BaseActivity[]
+        {
+            new HomeActivity(logger, videoPlayer),
+            new SearchActivity(logger, videoPlayer),
+            new ShortsActivity(logger),
+            new RecommendationActivity(logger, videoPlayer)
+        };
+
+        var manager = new WarmupManager(context, activities, _random);
+        await manager.RunAsync();
+
+        var snapshot = string.Join(" | ", activityLog.Snapshot());
+        if (!string.IsNullOrEmpty(snapshot))
+        {
+            logger.LogDebug("YouTube warmup log: {Log}", snapshot);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a modular YouTube warmup pipeline with configuration, session, and activity management helpers
- implement activity classes for search, home browsing, shorts, recommendations, and video engagement actions
- wire the new workflow into `YouTubeWarmupService` and enhance input validation and logging

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8845b2a08833081964aa78a7f7965