### PR TITLE
Modularize YouTube warmup behaviors

### DIFF
--- a/GPM_driver.Tests/GPM_driver.Tests.csproj
+++ b/GPM_driver.Tests/GPM_driver.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GPM_driver.csproj" />
+  </ItemGroup>
+</Project>

--- a/GPM_driver.Tests/YouTubeWarmupBehaviorTests.cs
+++ b/GPM_driver.Tests/YouTubeWarmupBehaviorTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using GPM_driver.Models;
+using GPM_driver.Services.YouTube.Behaviors;
+using Xunit;
+
+namespace GPM_driver.Tests;
+
+public class YouTubeWarmupBehaviorTests
+{
+    [Theory]
+    [InlineData("search")]
+    [InlineData("Searches")]
+    public void SearchBehaviorMatchesAliases(string alias)
+    {
+        var behavior = new SearchWarmupBehavior();
+
+        Assert.True(behavior.Matches(alias));
+    }
+
+    [Fact]
+    public void Calculator_PrioritizesSearchOnFreshLanding()
+    {
+        var calculator = new BehaviorWeightCalculator();
+        var config = new YouTubeWarmupSettings
+        {
+            Behaviors = new[] { "home", "search" }
+        };
+
+        var behaviors = new IYouTubeWarmupBehavior[]
+        {
+            new HomeWarmupBehavior(),
+            new SearchWarmupBehavior()
+        };
+
+        var weighted = calculator.Calculate(behaviors, config, freshLanding: true);
+
+        Assert.Contains(weighted, entry => entry.Behavior is SearchWarmupBehavior && entry.Weight > 0);
+        Assert.DoesNotContain(weighted, entry => entry.Behavior is HomeWarmupBehavior && entry.Weight > 0);
+
+        var chosen = calculator.PickBehavior(weighted, new System.Random(0));
+        Assert.IsType<SearchWarmupBehavior>(chosen);
+    }
+}

--- a/GPM_driver.sln
+++ b/GPM_driver.sln
@@ -4,17 +4,23 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GPM_driver", "GPM_driver.csproj", "{C744CC65-DE69-67B3-2CA3-D7C87B614924}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GPM_driver.Tests", "GPM_driver.Tests\\GPM_driver.Tests.csproj", "{D6AC4F70-2C58-4FFE-9C36-5A96396BF5CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C744CC65-DE69-67B3-2CA3-D7C87B614924}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C744CC65-DE69-67B3-2CA3-D7C87B614924}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C744CC65-DE69-67B3-2CA3-D7C87B614924}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C744CC65-DE69-67B3-2CA3-D7C87B614924}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {C744CC65-DE69-67B3-2CA3-D7C87B614924}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C744CC65-DE69-67B3-2CA3-D7C87B614924}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C744CC65-DE69-67B3-2CA3-D7C87B614924}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C744CC65-DE69-67B3-2CA3-D7C87B614924}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D6AC4F70-2C58-4FFE-9C36-5A96396BF5CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D6AC4F70-2C58-4FFE-9C36-5A96396BF5CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D6AC4F70-2C58-4FFE-9C36-5A96396BF5CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D6AC4F70-2C58-4FFE-9C36-5A96396BF5CB}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Helpers/NavigationPattern.cs
+++ b/Helpers/NavigationPattern.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Helpers;
+
+/// <summary>
+/// Provides convenience helpers for issuing navigation key presses with optional logging and
+/// realistic timing. The API mirrors what the warmup activities use when interacting with rich
+/// media players.
+/// </summary>
+internal static class NavigationPattern
+{
+    private static readonly Random Random = RandomProvider.Shared;
+
+    /// <summary>
+    /// Attempts to press the provided key using the page keyboard. A probability gate is available
+    /// so callers can model infrequent actions without additional plumbing. Returns <c>true</c> when
+    /// the key was actually pressed.
+    /// </summary>
+    public static async Task<bool> TryPressAsync(
+        IPage page,
+        string key,
+        double probability = 1.0,
+        int minDelayMs = 50,
+        int maxDelayMs = 150,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (probability < 1.0 && Random.NextDouble() > probability)
+        {
+            return false;
+        }
+
+        try
+        {
+            await page.Keyboard.PressAsync(key);
+
+            if (maxDelayMs > 0)
+            {
+                int clampedMin = Math.Max(0, minDelayMs);
+                int clampedMax = Math.Max(clampedMin, maxDelayMs);
+                int delay = Random.Next(clampedMin, clampedMax + 1);
+                if (delay > 0)
+                {
+                    await Task.Delay(delay, cancellationToken);
+                }
+            }
+
+            logger?.LogTrace("Pressed key '{Key}' on page {Url}.", key, page.Url);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Failed pressing key '{Key}' on {Url}.", key, page.Url);
+            return false;
+        }
+    }
+}

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -62,30 +62,24 @@ public class YouTubeWarmupSettings
     public bool Enabled { get; set; } = true;
     public int MinInteractions { get; set; } = 2;
     public int MaxInteractions { get; set; } = 5;
-    public double ContinueProbability { get; set; } = 0.35;
     public int MinWatchMilliseconds { get; set; } = 20000;
     public int MaxWatchMilliseconds { get; set; } = 55000;
     public int MinShortWatchMilliseconds { get; set; } = 8000;
     public int MaxShortWatchMilliseconds { get; set; } = 20000;
     public double SearchWeight { get; set; } = 0.5;
     public double ShortsWeight { get; set; } = 0.25;
+    public double HomeWeight { get; set; } = 0.35;
+    public double RecommendationsWeight { get; set; } = 0.25;
     public int MinDelayBetweenActionsMs { get; set; } = 2000;
     public int MaxDelayBetweenActionsMs { get; set; } = 5000;
     public string[] Domains { get; set; } = new[] { "https://www.youtube.com", "https://www.youtube.com/feed/explore" };
     public string IdentityCacheDirectory { get; set; } = "youtube-identities";
-    public int IdentityKeywordFileCount { get; set; } = 2;
-    public double RecommendationChainProbability { get; set; } = 0.55;
     public int MinRecommendationChainLength { get; set; } = 1;
     public int MaxRecommendationChainLength { get; set; } = 3;
     public int MaxRecommendationDepth { get; set; } = 3;
     public double AutoplayFollowProbability { get; set; } = 0.35;
     public int MinShortSequenceLength { get; set; } = 2;
     public int MaxShortSequenceLength { get; set; } = 5;
-    public string Persona { get; set; } = "Generalist";
-    public string Region { get; set; } = "Global";
-    public string Language { get; set; } = "en-US";
-    public string? Timezone { get; set; }
-        = null;
     public string[] Behaviors { get; set; }
         = new[] { "Search", "Home", "Shorts", "Recommendations" };
 }

--- a/Services/WarmupSession.cs
+++ b/Services/WarmupSession.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GPM_driver.Behaviors;
 using GPM_driver.Helpers;
 using GPM_driver.Models;
+using GPM_driver.Services.YouTube.Behaviors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 
@@ -190,7 +191,16 @@ internal class WarmupSession
         }
 
         var ytLogger = _loggerFactory.CreateLogger<YouTubeWarmupService>();
-        var youtubeWarmup = new YouTubeWarmupService(_context, ytLogger);
+        var behaviors = new IYouTubeWarmupBehavior[]
+        {
+            new SearchWarmupBehavior(_loggerFactory.CreateLogger<SearchWarmupBehavior>()),
+            new HomeWarmupBehavior(_loggerFactory.CreateLogger<HomeWarmupBehavior>()),
+            new ShortsWarmupBehavior(_loggerFactory.CreateLogger<ShortsWarmupBehavior>()),
+            new RecommendationWarmupBehavior(_loggerFactory.CreateLogger<RecommendationWarmupBehavior>())
+        };
+
+        var weightCalculator = new BehaviorWeightCalculator(_loggerFactory.CreateLogger<BehaviorWeightCalculator>());
+        var youtubeWarmup = new YouTubeWarmupService(_context, behaviors, weightCalculator, ytLogger, _loggerFactory);
 
         try
         {

--- a/Services/YouTube/Activities/VideoPlayerActivity.cs
+++ b/Services/YouTube/Activities/VideoPlayerActivity.cs
@@ -33,7 +33,8 @@ internal class VideoPlayerActivity
 
     public async Task WatchCurrentVideoAsync(
         TimeSpan watchDuration,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool? treatAsShortHint = null)
     {
         if (watchDuration <= TimeSpan.Zero)
         {
@@ -55,7 +56,25 @@ internal class VideoPlayerActivity
             return;
         }
 
-        var stopAt = DateTime.UtcNow + watchDuration;
+        var metadata = await _controls.TryGetPlaybackMetadataAsync(cancellationToken);
+        bool treatAsShort = treatAsShortHint ?? metadata?.IsShort ?? false;
+        TimeSpan effectiveDuration = DetermineEffectiveWatchDuration(watchDuration, metadata, treatAsShort);
+
+        if (effectiveDuration <= TimeSpan.Zero)
+        {
+            _logger?.LogWarning("Resolved non-positive watch duration for current video. Skipping warmup interaction.");
+            return;
+        }
+
+        if (effectiveDuration < watchDuration - TimeSpan.FromSeconds(1))
+        {
+            _logger?.LogInformation(
+                "Adjusting watch duration from {Requested} to {Actual} based on playback metadata.",
+                watchDuration,
+                effectiveDuration);
+        }
+
+        var stopAt = DateTime.UtcNow + effectiveDuration;
         bool firstLoop = true;
         int actionsPerformed = 0;
         int maxInteractions = DetermineMaxInteractionsPerVideo();
@@ -121,6 +140,75 @@ internal class VideoPlayerActivity
 
         await _controls.ExitFullScreenAsync(cancellationToken);
         _logger?.LogInformation("Completed watch routine on {Url}.", _page.Url);
+    }
+
+    private TimeSpan DetermineEffectiveWatchDuration(
+        TimeSpan requestedDuration,
+        PlayerControlHelper.VideoPlaybackMetadata? metadata,
+        bool treatAsShort)
+    {
+        if (metadata?.Duration is not TimeSpan totalDuration || totalDuration <= TimeSpan.Zero)
+        {
+            return requestedDuration;
+        }
+
+        double totalSeconds = totalDuration.TotalSeconds;
+        double currentSeconds = metadata.Position?.TotalSeconds ?? 0;
+        if (currentSeconds < 0 || currentSeconds > totalSeconds)
+        {
+            currentSeconds = 0;
+        }
+
+        double remainingSeconds = Math.Max(0, totalSeconds - currentSeconds);
+        if (remainingSeconds <= 1)
+        {
+            remainingSeconds = Math.Max(1, totalSeconds * 0.2);
+        }
+
+        double ratio = ChooseWatchRatio(totalDuration, treatAsShort);
+        double targetSeconds = Math.Min(remainingSeconds, totalSeconds * ratio);
+        targetSeconds = Math.Max(3, targetSeconds);
+
+        double requestedSeconds = Math.Max(1, requestedDuration.TotalSeconds);
+        double effectiveSeconds = Math.Min(requestedSeconds, targetSeconds);
+        effectiveSeconds = Math.Min(effectiveSeconds, remainingSeconds);
+
+        if (effectiveSeconds <= 1)
+        {
+            effectiveSeconds = Math.Min(remainingSeconds, Math.Max(3, Math.Min(requestedSeconds, totalSeconds)));
+        }
+
+        return TimeSpan.FromSeconds(effectiveSeconds);
+    }
+
+    private double ChooseWatchRatio(TimeSpan totalDuration, bool treatAsShort)
+    {
+        if (treatAsShort || totalDuration <= TimeSpan.FromSeconds(90))
+        {
+            return RandomRange(0.75, 0.97);
+        }
+
+        if (totalDuration <= TimeSpan.FromMinutes(5))
+        {
+            return RandomRange(0.45, 0.8);
+        }
+
+        if (totalDuration <= TimeSpan.FromMinutes(15))
+        {
+            return RandomRange(0.3, 0.6);
+        }
+
+        return RandomRange(0.15, 0.4);
+    }
+
+    private double RandomRange(double minInclusive, double maxInclusive)
+    {
+        if (maxInclusive <= minInclusive)
+        {
+            return minInclusive;
+        }
+
+        return minInclusive + (_random.NextDouble() * (maxInclusive - minInclusive));
     }
 
     private int ComputeNextDelay()

--- a/Services/YouTube/Activities/VideoPlayerActivity.cs
+++ b/Services/YouTube/Activities/VideoPlayerActivity.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GPM_driver.Helpers;
@@ -55,6 +57,11 @@ internal class VideoPlayerActivity
 
         var stopAt = DateTime.UtcNow + watchDuration;
         bool firstLoop = true;
+        int actionsPerformed = 0;
+        int maxInteractions = DetermineMaxInteractionsPerVideo();
+        var actionCounts = new Dictionary<PlayerControlHelper.PlayerControlAction, int>();
+        var failedActions = new HashSet<PlayerControlHelper.PlayerControlAction>();
+        var disabledActions = SelectActionsToDisable();
 
         while (DateTime.UtcNow < stopAt)
         {
@@ -66,18 +73,154 @@ internal class VideoPlayerActivity
                 continue;
             }
 
+            if (await _controls.IsAdOverlayBlockingControlsAsync(cancellationToken))
+            {
+                await _controls.TrySkipAdAsync(cancellationToken);
+                await _controls.DelayAsync(_random.Next(450, 850), cancellationToken);
+                continue;
+            }
+
             if (firstLoop)
             {
                 await _controls.EnsureVideoPlayingAsync(cancellationToken);
                 firstLoop = false;
             }
 
-            await _controls.PerformRandomControlActionAsync(cancellationToken);
+            bool interactionsAllowed = maxInteractions > 0 && actionsPerformed < maxInteractions;
+            bool shouldAct = interactionsAllowed && _random.NextDouble() > 0.65;
 
-            int delay = _random.Next(MinDelayBetweenActionsMs, MaxDelayBetweenActionsMs + 1);
+            int delay = ComputeNextDelay();
+
+            if (!shouldAct)
+            {
+                await _controls.DelayAsync(delay, cancellationToken);
+                continue;
+            }
+
+            PlayerControlHelper.PlayerControlAction? action = ChooseNextAction(actionCounts, failedActions, disabledActions);
+
+            if (action is null)
+            {
+                await _controls.DelayAsync(delay, cancellationToken);
+                continue;
+            }
+
+            bool success = await _controls.TryPerformActionAsync(action.Value, cancellationToken);
+            if (success)
+            {
+                actionsPerformed++;
+                actionCounts[action.Value] = actionCounts.TryGetValue(action.Value, out int count) ? count + 1 : 1;
+            }
+            else
+            {
+                failedActions.Add(action.Value);
+            }
+
             await _controls.DelayAsync(delay, cancellationToken);
         }
 
+        await _controls.ExitFullScreenAsync(cancellationToken);
         _logger?.LogInformation("Completed watch routine on {Url}.", _page.Url);
+    }
+
+    private int ComputeNextDelay()
+    {
+        int min = Math.Max(1500, Math.Min(MinDelayBetweenActionsMs, MaxDelayBetweenActionsMs));
+        int max = Math.Max(min + 500, Math.Max(MinDelayBetweenActionsMs, MaxDelayBetweenActionsMs));
+        return _random.Next(min, max + 1);
+    }
+
+    private int DetermineMaxInteractionsPerVideo()
+    {
+        double roll = _random.NextDouble();
+        return roll switch
+        {
+            < 0.35 => 0,
+            < 0.7 => 1,
+            < 0.9 => 2,
+            _ => 3
+        };
+    }
+
+    private HashSet<PlayerControlHelper.PlayerControlAction> SelectActionsToDisable()
+    {
+        var disabled = new HashSet<PlayerControlHelper.PlayerControlAction>();
+
+        foreach (var action in PlayerControlHelper.DefaultActionWeights.Keys)
+        {
+            double chance = action switch
+            {
+                PlayerControlHelper.PlayerControlAction.AdjustVolumeSlider => 0.65,
+                PlayerControlHelper.PlayerControlAction.AdjustVolumeKeys => 0.55,
+                PlayerControlHelper.PlayerControlAction.ChangePlaybackSpeed => 0.6,
+                PlayerControlHelper.PlayerControlAction.ToggleTheaterMode => 0.5,
+                PlayerControlHelper.PlayerControlAction.ToggleFullScreen => 0.45,
+                PlayerControlHelper.PlayerControlAction.ToggleMute => 0.45,
+                PlayerControlHelper.PlayerControlAction.SeekRelative => 0.35,
+                PlayerControlHelper.PlayerControlAction.TogglePlayPause => 0.3,
+                _ => 0.5
+            };
+
+            if (_random.NextDouble() < chance)
+            {
+                disabled.Add(action);
+            }
+        }
+
+        if (disabled.Count >= PlayerControlHelper.DefaultActionWeights.Count)
+        {
+            var actions = PlayerControlHelper.DefaultActionWeights.Keys.ToList();
+            disabled.Remove(actions[_random.Next(actions.Count)]);
+        }
+
+        return disabled;
+    }
+
+    private PlayerControlHelper.PlayerControlAction? ChooseNextAction(
+        IDictionary<PlayerControlHelper.PlayerControlAction, int> counts,
+        ISet<PlayerControlHelper.PlayerControlAction> failed,
+        ISet<PlayerControlHelper.PlayerControlAction> disabled)
+    {
+        var candidates = new List<(PlayerControlHelper.PlayerControlAction Action, double Weight)>();
+
+        foreach (var kvp in PlayerControlHelper.DefaultActionWeights)
+        {
+            if (disabled.Contains(kvp.Key))
+            {
+                continue;
+            }
+
+            if (failed.Contains(kvp.Key))
+            {
+                continue;
+            }
+
+            if (counts.TryGetValue(kvp.Key, out int count) && count >= 2)
+            {
+                continue;
+            }
+
+            double jitter = 0.75 + (_random.NextDouble() * 0.5);
+            candidates.Add((kvp.Key, kvp.Value * jitter));
+        }
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        double total = candidates.Sum(c => c.Weight);
+        double roll = _random.NextDouble() * total;
+
+        foreach (var candidate in candidates)
+        {
+            roll -= candidate.Weight;
+            if (roll <= 0)
+            {
+                return candidate.Action;
+            }
+        }
+
+        return candidates.Last().Action;
     }
 }

--- a/Services/YouTube/Activities/VideoPlayerActivity.cs
+++ b/Services/YouTube/Activities/VideoPlayerActivity.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Services.YouTube;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Activities;
+
+/// <summary>
+/// Represents a warmup activity that watches the currently loaded YouTube video while interacting
+/// with the player controls in a realistic manner.
+/// </summary>
+internal class VideoPlayerActivity
+{
+    private readonly IPage _page;
+    private readonly PlayerControlHelper _controls;
+    private readonly ILogger<VideoPlayerActivity>? _logger;
+    private readonly Random _random = RandomProvider.Shared;
+
+    public int MinDelayBetweenActionsMs { get; set; } = 2500;
+    public int MaxDelayBetweenActionsMs { get; set; } = 6000;
+
+    public VideoPlayerActivity(IPage page, ILogger<VideoPlayerActivity>? logger = null, PlayerControlHelper? controlHelper = null)
+    {
+        _page = page ?? throw new ArgumentNullException(nameof(page));
+        _logger = logger;
+        _controls = controlHelper ?? new PlayerControlHelper(page, logger: logger);
+    }
+
+    public async Task WatchCurrentVideoAsync(
+        TimeSpan watchDuration,
+        CancellationToken cancellationToken = default)
+    {
+        if (watchDuration <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        _logger?.LogInformation("Watching current YouTube video for {Duration}.", watchDuration);
+
+        bool playerReady = await _controls.EnsurePlayerVisibleAsync();
+        if (!playerReady)
+        {
+            _logger?.LogWarning("Unable to locate visible YouTube player. Skipping watch routine.");
+            return;
+        }
+
+        var stopAt = DateTime.UtcNow + watchDuration;
+        bool firstLoop = true;
+
+        while (DateTime.UtcNow < stopAt)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await _controls.HandleAdsAsync(cancellationToken))
+            {
+                // Ads consume time but we resume the loop immediately afterwards.
+                continue;
+            }
+
+            if (firstLoop)
+            {
+                await _controls.EnsureVideoPlayingAsync(cancellationToken);
+                firstLoop = false;
+            }
+
+            await _controls.PerformRandomControlActionAsync(cancellationToken);
+
+            int delay = _random.Next(MinDelayBetweenActionsMs, MaxDelayBetweenActionsMs + 1);
+            await _controls.DelayAsync(delay, cancellationToken);
+        }
+
+        _logger?.LogInformation("Completed watch routine on {Url}.", _page.Url);
+    }
+}

--- a/Services/YouTube/Activities/VideoPlayerActivity.cs
+++ b/Services/YouTube/Activities/VideoPlayerActivity.cs
@@ -40,6 +40,12 @@ internal class VideoPlayerActivity
 
         _logger?.LogInformation("Watching current YouTube video for {Duration}.", watchDuration);
 
+        if (!await _controls.WaitForPlayerReadyAsync(cancellationToken))
+        {
+            _logger?.LogWarning("Timed out waiting for YouTube player to become ready.");
+            return;
+        }
+
         bool playerReady = await _controls.EnsurePlayerVisibleAsync();
         if (!playerReady)
         {

--- a/Services/YouTube/Behaviors/BehaviorWeightCalculator.cs
+++ b/Services/YouTube/Behaviors/BehaviorWeightCalculator.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+
+namespace GPM_driver.Services.YouTube.Behaviors;
+
+internal sealed class BehaviorWeightCalculator
+{
+    private readonly ILogger<BehaviorWeightCalculator>? _logger;
+
+    public BehaviorWeightCalculator(ILogger<BehaviorWeightCalculator>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public IReadOnlyList<(IYouTubeWarmupBehavior Behavior, double Weight)> Calculate(
+        IEnumerable<IYouTubeWarmupBehavior> registry,
+        YouTubeWarmupSettings config,
+        bool freshLanding)
+    {
+        var available = registry?.ToList() ?? new List<IYouTubeWarmupBehavior>();
+        if (available.Count == 0)
+        {
+            _logger?.LogWarning("No YouTube warmup behaviours registered.");
+            return Array.Empty<(IYouTubeWarmupBehavior, double)>();
+        }
+
+        var filtered = FilterBehaviors(available, config?.Behaviors);
+        if (filtered.Count == 0)
+        {
+            filtered = available;
+        }
+
+        var results = new List<(IYouTubeWarmupBehavior, double)>();
+        foreach (var behavior in filtered.Distinct())
+        {
+            double weight = GetWeightForBehavior(behavior.Kind, config, freshLanding);
+            if (weight <= 0)
+            {
+                continue;
+            }
+
+            results.Add((behavior, weight));
+        }
+
+        if (results.Count == 0)
+        {
+            var fallback = available.FirstOrDefault(b => b.Kind == YouTubeWarmupBehaviorKind.Search)
+                ?? available.First();
+            results.Add((fallback, 1.0));
+        }
+
+        return results;
+    }
+
+    public IYouTubeWarmupBehavior? PickBehavior(
+        IReadOnlyList<(IYouTubeWarmupBehavior Behavior, double Weight)> weighted,
+        Random random)
+    {
+        if (weighted == null || weighted.Count == 0)
+        {
+            return null;
+        }
+
+        double total = weighted.Sum(entry => entry.Weight);
+        if (total <= 0)
+        {
+            return weighted[^1].Behavior;
+        }
+
+        double roll = random.NextDouble() * total;
+        double cumulative = 0;
+
+        foreach (var entry in weighted)
+        {
+            cumulative += entry.Weight;
+            if (roll <= cumulative)
+            {
+                return entry.Behavior;
+            }
+        }
+
+        return weighted[^1].Behavior;
+    }
+
+    private static List<IYouTubeWarmupBehavior> FilterBehaviors(
+        IEnumerable<IYouTubeWarmupBehavior> registry,
+        string[]? requested)
+    {
+        if (requested == null || requested.Length == 0)
+        {
+            return registry.ToList();
+        }
+
+        var results = new List<IYouTubeWarmupBehavior>();
+        foreach (string name in requested)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            var match = registry.FirstOrDefault(behavior => behavior.Matches(name));
+            if (match != null && !results.Contains(match))
+            {
+                results.Add(match);
+            }
+        }
+
+        return results;
+    }
+
+    private static double GetWeightForBehavior(
+        YouTubeWarmupBehaviorKind kind,
+        YouTubeWarmupSettings config,
+        bool freshLanding)
+    {
+        if (config == null)
+        {
+            return kind == YouTubeWarmupBehaviorKind.Search ? 1.0 : 0.0;
+        }
+
+        if (freshLanding)
+        {
+            return kind switch
+            {
+                YouTubeWarmupBehaviorKind.Search => 0.7,
+                YouTubeWarmupBehaviorKind.Shorts => 0.3,
+                YouTubeWarmupBehaviorKind.Home => 0.0,
+                YouTubeWarmupBehaviorKind.Recommendations => 0.0,
+                _ => 0.0
+            };
+        }
+
+        return kind switch
+        {
+            YouTubeWarmupBehaviorKind.Search => Math.Max(0.01, config.SearchWeight),
+            YouTubeWarmupBehaviorKind.Home => Math.Max(0.01, config.HomeWeight),
+            YouTubeWarmupBehaviorKind.Shorts => Math.Max(0.01, config.ShortsWeight),
+            YouTubeWarmupBehaviorKind.Recommendations => Math.Max(0.01, config.RecommendationsWeight),
+            _ => 0.0
+        };
+    }
+}

--- a/Services/YouTube/Behaviors/HomeWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/HomeWarmupBehavior.cs
@@ -38,6 +38,12 @@ internal sealed class HomeWarmupBehavior : IYouTubeWarmupBehavior
 
         await context.NavigateToHomeAsync(config, token);
 
+        if (!await WaitForHomeFeedAsync(page, token))
+        {
+            _logger?.LogWarning("Home feed did not return any clickable videos.");
+            return false;
+        }
+
         var items = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer a#thumbnail, ytd-rich-item-renderer #video-title-link");
         int count = await items.CountAsync();
         if (count == 0)
@@ -50,6 +56,7 @@ internal sealed class HomeWarmupBehavior : IYouTubeWarmupBehavior
         var item = items.Nth(index);
         try
         {
+            await item.ScrollIntoViewIfNeededAsync();
             await mouse.MoveAndClickAsync(item);
             await context.WaitForNavigationAsync(token);
         }
@@ -62,5 +69,21 @@ internal sealed class HomeWarmupBehavior : IYouTubeWarmupBehavior
         await context.WatchVideoAsync(config, token);
         context.IncrementHomeInteractions();
         return true;
+    }
+
+    private async Task<bool> WaitForHomeFeedAsync(IPage page, CancellationToken token)
+    {
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            var gridItems = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer");
+            await gridItems.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Timed out waiting for YouTube home feed.");
+            return false;
+        }
     }
 }

--- a/Services/YouTube/Behaviors/HomeWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/HomeWarmupBehavior.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Behaviors;
+
+internal sealed class HomeWarmupBehavior : IYouTubeWarmupBehavior
+{
+    private readonly ILogger<HomeWarmupBehavior>? _logger;
+
+    public HomeWarmupBehavior(ILogger<HomeWarmupBehavior>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public string Name => "Home";
+
+    public YouTubeWarmupBehaviorKind Kind => YouTubeWarmupBehaviorKind.Home;
+
+    public IEnumerable<string> Aliases { get; } = new[] { "home", "feed" };
+
+    public bool Matches(string identifier)
+        => Aliases.Any(alias => alias.Equals(identifier, StringComparison.OrdinalIgnoreCase));
+
+    public async Task<bool> ExecuteAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        if (page == null || mouse == null)
+        {
+            return false;
+        }
+
+        await context.NavigateToHomeAsync(config, token);
+
+        var items = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer a#thumbnail, ytd-rich-item-renderer #video-title-link");
+        int count = await items.CountAsync();
+        if (count == 0)
+        {
+            _logger?.LogWarning("Home feed did not return any clickable videos.");
+            return false;
+        }
+
+        int index = context.Random.Next(0, Math.Min(count, 8));
+        var item = items.Nth(index);
+        try
+        {
+            await mouse.MoveAndClickAsync(item);
+            await context.WaitForNavigationAsync(token);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed clicking home feed item {Index}.", index);
+            return false;
+        }
+
+        await context.WatchVideoAsync(config, token);
+        context.IncrementHomeInteractions();
+        return true;
+    }
+}

--- a/Services/YouTube/Behaviors/IYouTubeWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/IYouTubeWarmupBehavior.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Models;
+
+namespace GPM_driver.Services.YouTube.Behaviors;
+
+internal enum YouTubeWarmupBehaviorKind
+{
+    Search,
+    Home,
+    Shorts,
+    Recommendations
+}
+
+internal interface IYouTubeWarmupBehavior
+{
+    string Name { get; }
+
+    YouTubeWarmupBehaviorKind Kind { get; }
+
+    IEnumerable<string> Aliases { get; }
+
+    bool Matches(string identifier);
+
+    Task<bool> ExecuteAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token);
+}

--- a/Services/YouTube/Behaviors/RecommendationWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/RecommendationWarmupBehavior.cs
@@ -87,6 +87,12 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
 
         await context.NavigateToHomeAsync(config, token);
 
+        if (!await WaitForHomeFeedAsync(page, token))
+        {
+            _logger?.LogWarning("Home feed did not return any clickable videos for recommendation chain.");
+            return false;
+        }
+
         var items = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer a#thumbnail, ytd-rich-item-renderer #video-title-link");
         int count = await items.CountAsync();
         if (count == 0)
@@ -99,6 +105,7 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
         var item = items.Nth(index);
         try
         {
+            await item.ScrollIntoViewIfNeededAsync();
             await mouse.MoveAndClickAsync(item);
             await context.WaitForNavigationAsync(token);
         }
@@ -121,6 +128,12 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
             return;
         }
 
+        if (!await WaitForRecommendationPanelAsync(page, token))
+        {
+            _logger?.LogDebug("No recommendation thumbnails available to follow.");
+            return;
+        }
+
         var recommendations = page.Locator("#items ytd-compact-video-renderer a#thumbnail, #secondary ytd-compact-video-renderer #video-title");
         int count = await recommendations.CountAsync();
         if (count == 0)
@@ -134,12 +147,45 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
 
         try
         {
+            await recommendation.ScrollIntoViewIfNeededAsync();
             await mouse.MoveAndClickAsync(recommendation);
             await context.WaitForNavigationAsync(token);
         }
         catch (PlaywrightException ex)
         {
             _logger?.LogDebug(ex, "Failed to follow recommendation at index {Index}.", index);
+        }
+    }
+
+    private async Task<bool> WaitForHomeFeedAsync(IPage page, CancellationToken token)
+    {
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            var gridItems = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer");
+            await gridItems.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Timed out waiting for YouTube home feed before recommendation chain.");
+            return false;
+        }
+    }
+
+    private async Task<bool> WaitForRecommendationPanelAsync(IPage page, CancellationToken token)
+    {
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            var panelItems = page.Locator("#items ytd-compact-video-renderer, #secondary ytd-compact-video-renderer");
+            await panelItems.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 10000 });
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Timed out waiting for recommendation panel items.");
+            return false;
         }
     }
 }

--- a/Services/YouTube/Behaviors/RecommendationWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/RecommendationWarmupBehavior.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Behaviors;
+
+internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
+{
+    private readonly ILogger<RecommendationWarmupBehavior>? _logger;
+
+    public RecommendationWarmupBehavior(ILogger<RecommendationWarmupBehavior>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public string Name => "Recommendations";
+
+    public YouTubeWarmupBehaviorKind Kind => YouTubeWarmupBehaviorKind.Recommendations;
+
+    public IEnumerable<string> Aliases { get; } = new[] { "recommendation", "recommendations", "upnext" };
+
+    public bool Matches(string identifier)
+        => Aliases.Any(alias => alias.Equals(identifier, StringComparison.OrdinalIgnoreCase));
+
+    public async Task<bool> ExecuteAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        if (page == null || mouse == null)
+        {
+            return false;
+        }
+
+        int chainLength = context.Random.Next(
+            Math.Max(1, config.MinRecommendationChainLength),
+            Math.Max(Math.Max(1, config.MinRecommendationChainLength), config.MaxRecommendationChainLength) + 1);
+        chainLength = Math.Min(chainLength, Math.Max(1, config.MaxRecommendationDepth));
+
+        bool started = await StartFromHomeAsync(context, config, token);
+        if (!started)
+        {
+            return false;
+        }
+
+        for (int step = 1; step < chainLength; step++)
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (context.Random.NextDouble() < config.AutoplayFollowProbability)
+            {
+                string currentId = context.ExtractVideoId(page.Url);
+                await Task.Delay(context.Random.Next(6000, 9000), token);
+                if (!string.Equals(currentId, context.ExtractVideoId(page.Url), StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger?.LogDebug("Autoplay advanced to new video.");
+                }
+                else
+                {
+                    await FollowRecommendationAsync(context, token);
+                }
+            }
+            else
+            {
+                await FollowRecommendationAsync(context, token);
+            }
+
+            await context.WatchVideoAsync(config, token);
+        }
+
+        context.IncrementRecommendationInteractions();
+        return true;
+    }
+
+    private async Task<bool> StartFromHomeAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        if (page == null || mouse == null)
+        {
+            return false;
+        }
+
+        await context.NavigateToHomeAsync(config, token);
+
+        var items = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer a#thumbnail, ytd-rich-item-renderer #video-title-link");
+        int count = await items.CountAsync();
+        if (count == 0)
+        {
+            _logger?.LogWarning("Home feed did not return any clickable videos for recommendation chain.");
+            return false;
+        }
+
+        int index = context.Random.Next(0, Math.Min(count, 6));
+        var item = items.Nth(index);
+        try
+        {
+            await mouse.MoveAndClickAsync(item);
+            await context.WaitForNavigationAsync(token);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed to open initial video for recommendation chain.");
+            return false;
+        }
+
+        await context.WatchVideoAsync(config, token);
+        return true;
+    }
+
+    private async Task FollowRecommendationAsync(WarmupContext context, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        if (page == null || mouse == null)
+        {
+            return;
+        }
+
+        var recommendations = page.Locator("#items ytd-compact-video-renderer a#thumbnail, #secondary ytd-compact-video-renderer #video-title");
+        int count = await recommendations.CountAsync();
+        if (count == 0)
+        {
+            _logger?.LogDebug("No recommendation thumbnails available to follow.");
+            return;
+        }
+
+        int index = context.Random.Next(0, Math.Min(count, 8));
+        var recommendation = recommendations.Nth(index);
+
+        try
+        {
+            await mouse.MoveAndClickAsync(recommendation);
+            await context.WaitForNavigationAsync(token);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed to follow recommendation at index {Index}.", index);
+        }
+    }
+}

--- a/Services/YouTube/Behaviors/RecommendationWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/RecommendationWarmupBehavior.cs
@@ -93,7 +93,7 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
             return false;
         }
 
-        var items = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer a#thumbnail, ytd-rich-item-renderer #video-title-link");
+        var items = page.Locator("ytd-rich-item-renderer");
         int count = await items.CountAsync();
         if (count == 0)
         {
@@ -106,7 +106,16 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
         try
         {
             await item.ScrollIntoViewIfNeededAsync();
-            await mouse.MoveAndClickAsync(item);
+            var anchors = item.Locator("a#thumbnail, #video-title-link, a.yt-simple-endpoint");
+            if (await anchors.CountAsync() == 0)
+            {
+                _logger?.LogDebug("No clickable anchor found within home grid item at index {Index}.", index);
+                return false;
+            }
+
+            var clickable = anchors.First;
+            await clickable.ScrollIntoViewIfNeededAsync();
+            await mouse.MoveAndClickAsync(clickable);
             await context.WaitForNavigationAsync(token);
         }
         catch (PlaywrightException ex)
@@ -134,7 +143,7 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
             return;
         }
 
-        var recommendations = page.Locator("#items ytd-compact-video-renderer a#thumbnail, #secondary ytd-compact-video-renderer #video-title");
+        var recommendations = page.Locator("#items > yt-lockup-view-model, #secondary yt-lockup-view-model");
         int count = await recommendations.CountAsync();
         if (count == 0)
         {
@@ -148,7 +157,16 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
         try
         {
             await recommendation.ScrollIntoViewIfNeededAsync();
-            await mouse.MoveAndClickAsync(recommendation);
+            var anchors = recommendation.Locator("a#thumbnail, a#video-title-link, a.yt-simple-endpoint");
+            if (await anchors.CountAsync() == 0)
+            {
+                _logger?.LogDebug("No clickable anchor found within recommendation at index {Index}.", index);
+                return;
+            }
+
+            var clickable = anchors.First;
+            await clickable.ScrollIntoViewIfNeededAsync();
+            await mouse.MoveAndClickAsync(clickable);
             await context.WaitForNavigationAsync(token);
         }
         catch (PlaywrightException ex)
@@ -162,7 +180,9 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
         try
         {
             token.ThrowIfCancellationRequested();
-            var gridItems = page.Locator("ytd-rich-grid-row ytd-rich-item-renderer");
+            var contents = page.Locator("#contents");
+            await contents.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
+            var gridItems = contents.Locator("ytd-rich-item-renderer");
             await gridItems.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
             return true;
         }
@@ -178,7 +198,7 @@ internal sealed class RecommendationWarmupBehavior : IYouTubeWarmupBehavior
         try
         {
             token.ThrowIfCancellationRequested();
-            var panelItems = page.Locator("#items ytd-compact-video-renderer, #secondary ytd-compact-video-renderer");
+            var panelItems = page.Locator("#items > yt-lockup-view-model, #secondary yt-lockup-view-model");
             await panelItems.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 10000 });
             return true;
         }

--- a/Services/YouTube/Behaviors/SearchWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/SearchWarmupBehavior.cs
@@ -94,21 +94,33 @@ internal sealed class SearchWarmupBehavior : IYouTubeWarmupBehavior
 
         await context.WaitForNavigationAsync(token);
 
-        var results = page.Locator("ytd-video-renderer a#thumbnail, ytd-video-renderer #video-title-link");
-        if (!await results.First.IsVisibleAsync(new() { Timeout = 7000 }))
+        if (!await WaitForSearchResultsAsync(page, token))
         {
             _logger?.LogWarning("No visible search results located for keyword '{Keyword}'.", keyword);
             return false;
         }
 
+        var results = page.Locator("ytd-video-renderer a#thumbnail, ytd-video-renderer #video-title-link");
         int count = await page.Locator("ytd-video-renderer").CountAsync();
         int index = context.Random.Next(0, Math.Min(count, 5));
         var target = results.Nth(index);
 
         try
         {
+            await target.ScrollIntoViewIfNeededAsync();
             await mouse.MoveAndClickAsync(target);
             await context.WaitForNavigationAsync(token);
+            try
+            {
+                await page.WaitForURLAsync(
+                    url => url.Contains("watch", StringComparison.OrdinalIgnoreCase)
+                        || url.Contains("/shorts/", StringComparison.OrdinalIgnoreCase),
+                    new() { Timeout = 15000 });
+            }
+            catch (PlaywrightException ex)
+            {
+                _logger?.LogDebug(ex, "URL wait after opening search result timed out.");
+            }
         }
         catch (PlaywrightException ex)
         {
@@ -130,6 +142,22 @@ internal sealed class SearchWarmupBehavior : IYouTubeWarmupBehavior
         }
 
         return _cachedKeywords[context.Random.Next(_cachedKeywords.Count)];
+    }
+
+    private async Task<bool> WaitForSearchResultsAsync(IPage page, CancellationToken token)
+    {
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            var results = page.Locator("ytd-video-renderer");
+            await results.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Waiting for search results timed out.");
+            return false;
+        }
     }
 
     private async Task<List<string>> LoadKeywordsAsync(string? directory, CancellationToken token)

--- a/Services/YouTube/Behaviors/SearchWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/SearchWarmupBehavior.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Behaviors;
+
+internal sealed class SearchWarmupBehavior : IYouTubeWarmupBehavior
+{
+    private readonly ILogger<SearchWarmupBehavior>? _logger;
+    private List<string>? _cachedKeywords;
+
+    public SearchWarmupBehavior(ILogger<SearchWarmupBehavior>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public string Name => "Search";
+
+    public YouTubeWarmupBehaviorKind Kind => YouTubeWarmupBehaviorKind.Search;
+
+    public IEnumerable<string> Aliases { get; } = new[] { "search", "searches" };
+
+    public bool Matches(string identifier)
+        => Aliases.Any(alias => alias.Equals(identifier, StringComparison.OrdinalIgnoreCase));
+
+    public async Task<bool> ExecuteAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        var keyboard = context.Keyboard;
+        if (page == null || mouse == null || keyboard == null)
+        {
+            return false;
+        }
+
+        string keyword = await GetRandomKeywordAsync(context, token);
+        if (string.IsNullOrWhiteSpace(keyword))
+        {
+            return false;
+        }
+
+        await context.NavigateToHomeAsync(config, token);
+
+        var searchInput = page.Locator("input#search");
+        if (!await searchInput.IsVisibleAsync(new() { Timeout = 3000 }))
+        {
+            _logger?.LogDebug("Search input not visible; attempting keyboard shortcut.");
+            await page.Keyboard.PressAsync("/");
+            await Task.Delay(context.Random.Next(200, 450), token);
+        }
+
+        if (!await searchInput.IsVisibleAsync(new() { Timeout = 3000 }))
+        {
+            _logger?.LogWarning("Unable to locate YouTube search box.");
+            return false;
+        }
+
+        await mouse.MoveAndClickAsync(searchInput);
+        await page.Keyboard.PressAsync("Control+A");
+        await Task.Delay(context.Random.Next(100, 250), token);
+        await page.Keyboard.PressAsync("Backspace");
+
+        await keyboard.TypeLikeHumanAsync(searchInput, keyword);
+
+        if (context.Random.NextDouble() < 0.35)
+        {
+            await Task.Delay(context.Random.Next(400, 900), token);
+            int arrowPresses = context.Random.Next(1, 3);
+            await keyboard.PressNavigationKeyAsync("ArrowDown", arrowPresses);
+        }
+
+        if (context.Random.NextDouble() < 0.2)
+        {
+            var searchButton = page.Locator("button#search-icon-legacy");
+            if (await searchButton.IsVisibleAsync(new() { Timeout = 1500 }))
+            {
+                await mouse.MoveAndClickAsync(searchButton);
+            }
+            else
+            {
+                await page.Keyboard.PressAsync("Enter");
+            }
+        }
+        else
+        {
+            await page.Keyboard.PressAsync("Enter");
+        }
+
+        await context.WaitForNavigationAsync(token);
+
+        var results = page.Locator("ytd-video-renderer a#thumbnail, ytd-video-renderer #video-title-link");
+        if (!await results.First.IsVisibleAsync(new() { Timeout = 7000 }))
+        {
+            _logger?.LogWarning("No visible search results located for keyword '{Keyword}'.", keyword);
+            return false;
+        }
+
+        int count = await page.Locator("ytd-video-renderer").CountAsync();
+        int index = context.Random.Next(0, Math.Min(count, 5));
+        var target = results.Nth(index);
+
+        try
+        {
+            await mouse.MoveAndClickAsync(target);
+            await context.WaitForNavigationAsync(token);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed to open search result.");
+            return false;
+        }
+
+        await context.WatchVideoAsync(config, token);
+        context.IncrementSearchInteractions();
+        return true;
+    }
+
+    private async Task<string> GetRandomKeywordAsync(WarmupContext context, CancellationToken token)
+    {
+        _cachedKeywords ??= await LoadKeywordsAsync(context.KeywordDirectory, token);
+        if (_cachedKeywords.Count == 0)
+        {
+            return "latest music";
+        }
+
+        return _cachedKeywords[context.Random.Next(_cachedKeywords.Count)];
+    }
+
+    private async Task<List<string>> LoadKeywordsAsync(string? directory, CancellationToken token)
+    {
+        var results = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(directory) && Directory.Exists(directory))
+        {
+            try
+            {
+                foreach (string file in Directory.EnumerateFiles(directory, "*.txt"))
+                {
+                    using var stream = File.OpenRead(file);
+                    using var reader = new StreamReader(stream);
+                    while (!reader.EndOfStream)
+                    {
+                        token.ThrowIfCancellationRequested();
+                        string? line = await reader.ReadLineAsync();
+                        if (!string.IsNullOrWhiteSpace(line))
+                        {
+                            results.Add(line.Trim());
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger?.LogWarning(ex, "Failed to load YouTube keywords from {Directory}.", directory);
+            }
+        }
+
+        if (results.Count == 0)
+        {
+            results.AddRange(new[]
+            {
+                "daily tech news",
+                "travel vlogs",
+                "cooking tutorials",
+                "music live performance",
+                "gaming highlights",
+                "productivity tips"
+            });
+        }
+
+        return results;
+    }
+}

--- a/Services/YouTube/Behaviors/SearchWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/SearchWarmupBehavior.cs
@@ -47,7 +47,7 @@ internal sealed class SearchWarmupBehavior : IYouTubeWarmupBehavior
 
         await context.NavigateToHomeAsync(config, token);
 
-        var searchInput = page.Locator("input#search");
+        var searchInput = page.Locator("input[name='search_query']");
         if (!await searchInput.IsVisibleAsync(new() { Timeout = 3000 }))
         {
             _logger?.LogDebug("Search input not visible; attempting keyboard shortcut.");
@@ -77,7 +77,7 @@ internal sealed class SearchWarmupBehavior : IYouTubeWarmupBehavior
 
         if (context.Random.NextDouble() < 0.2)
         {
-            var searchButton = page.Locator("button#search-icon-legacy");
+            var searchButton = page.Locator("button[class='ytSearchboxComponentSearchButton']");
             if (await searchButton.IsVisibleAsync(new() { Timeout = 1500 }))
             {
                 await mouse.MoveAndClickAsync(searchButton);

--- a/Services/YouTube/Behaviors/ShortsWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/ShortsWarmupBehavior.cs
@@ -86,29 +86,65 @@ internal sealed class ShortsWarmupBehavior : IYouTubeWarmupBehavior
             return false;
         }
 
-        try
+        var navigationSelectors = new[]
         {
-            var menuItems = page.Locator("#items ytd-mini-guide-entry-renderer");
-            int count = await menuItems.CountAsync();
-            for (int i = 0; i < Math.Min(count, 8); i++)
+            "#items ytd-mini-guide-entry-renderer[aria-label*='Shorts' i]",
+            "#items ytd-mini-guide-entry-renderer:has-text('Shorts')",
+            "ytd-guide-entry-renderer[aria-label*='Shorts' i] a",
+            "a[title*='Shorts' i]",
+            "a[aria-label*='Shorts' i]",
+            "#endpoint[href^='/shorts']"
+        };
+
+        foreach (string selector in navigationSelectors)
+        {
+            try
             {
-                var entry = menuItems.Nth(i);
-                string label = (await entry.InnerTextAsync(new() { Timeout = 1000 }))?.Trim() ?? string.Empty;
-                if (label.IndexOf("shorts", StringComparison.OrdinalIgnoreCase) >= 0)
+                var candidates = page.Locator(selector);
+                int count = await candidates.CountAsync();
+                for (int i = 0; i < Math.Min(count, 5); i++)
                 {
-                    await mouse.MoveAndClickAsync(entry);
-                    await context.WaitForNavigationAsync(token);
-                    return true;
+                    var entry = candidates.Nth(i);
+                    if (!await entry.IsVisibleAsync(new() { Timeout = 1000 }))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        await entry.ScrollIntoViewIfNeededAsync();
+                    }
+                    catch (PlaywrightException)
+                    {
+                        // Continue even if scrolling fails; clicking may still succeed.
+                    }
+
+                    try
+                    {
+                        await mouse.MoveAndClickAsync(entry);
+                        await context.WaitForNavigationAsync(token);
+
+                        if (page.Url.Contains("/shorts", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                    catch (PlaywrightException ex)
+                    {
+                        _logger?.LogDebug(ex, "Failed to activate Shorts via selector {Selector}.", selector);
+                    }
                 }
             }
-        }
-        catch (PlaywrightException ex)
-        {
-            _logger?.LogDebug(ex, "Mini guide navigation to Shorts failed; falling back to direct navigation.");
+            catch (PlaywrightException ex)
+            {
+                _logger?.LogTrace(ex, "Selector {Selector} lookup failed while opening Shorts feed.", selector);
+            }
         }
 
         string fallback = config.Domains?.FirstOrDefault(d => d.Contains("/shorts", StringComparison.OrdinalIgnoreCase))
             ?? "https://www.youtube.com/shorts";
+
+        _logger?.LogDebug("Falling back to direct Shorts navigation at {Url}.", fallback);
 
         try
         {
@@ -134,15 +170,26 @@ internal sealed class ShortsWarmupBehavior : IYouTubeWarmupBehavior
         try
         {
             token.ThrowIfCancellationRequested();
-            var player = page.Locator("#shorts-player video, #reel-video-renderer video, video.html5-main-video");
-            await player.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
+
+            var container = page.Locator("#shorts-player, #reel-video-renderer");
+            if (await container.CountAsync() == 0)
+            {
+                _logger?.LogDebug("Shorts container elements not found after navigation.");
+                return false;
+            }
+
+            await container.First.WaitForAsync(new()
+            {
+                State = WaitForSelectorState.Visible,
+                Timeout = 12000
+            });
         }
         catch (PlaywrightException ex)
         {
-            _logger?.LogDebug(ex, "Shorts player did not become visible in time.");
+            _logger?.LogDebug(ex, "Shorts container did not become visible in time.");
             return false;
         }
 
-        return await context.PlayerControls.WaitForPlayerReadyAsync(token, 12000);
+        return await context.PlayerControls.WaitForPlayerReadyAsync(token, 15000);
     }
 }

--- a/Services/YouTube/Behaviors/ShortsWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/ShortsWarmupBehavior.cs
@@ -42,6 +42,12 @@ internal sealed class ShortsWarmupBehavior : IYouTubeWarmupBehavior
             return false;
         }
 
+        if (!await WaitForShortsPlayerAsync(context, token))
+        {
+            _logger?.LogWarning("Unable to detect Shorts player after navigation.");
+            return false;
+        }
+
         int sequenceLength = context.Random.Next(
             Math.Max(1, config.MinShortSequenceLength),
             Math.Max(Math.Max(1, config.MinShortSequenceLength), config.MaxShortSequenceLength) + 1);
@@ -59,6 +65,11 @@ internal sealed class ShortsWarmupBehavior : IYouTubeWarmupBehavior
                 string key = context.Random.NextDouble() < 0.65 ? "ArrowDown" : "PageDown";
                 await page.Keyboard.PressAsync(key);
                 await Task.Delay(context.Random.Next(800, 1600), token);
+                if (!await WaitForShortsPlayerAsync(context, token))
+                {
+                    _logger?.LogDebug("Shorts player did not become ready after advancing.");
+                    break;
+                }
             }
         }
 
@@ -110,5 +121,28 @@ internal sealed class ShortsWarmupBehavior : IYouTubeWarmupBehavior
             _logger?.LogWarning(ex, "Failed to open Shorts experience at {Url}.", fallback);
             return false;
         }
+    }
+
+    private async Task<bool> WaitForShortsPlayerAsync(WarmupContext context, CancellationToken token)
+    {
+        var page = context.Page;
+        if (page == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            token.ThrowIfCancellationRequested();
+            var player = page.Locator("#shorts-player video, #reel-video-renderer video, video.html5-main-video");
+            await player.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 12000 });
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Shorts player did not become visible in time.");
+            return false;
+        }
+
+        return await context.PlayerControls.WaitForPlayerReadyAsync(token, 12000);
     }
 }

--- a/Services/YouTube/Behaviors/ShortsWarmupBehavior.cs
+++ b/Services/YouTube/Behaviors/ShortsWarmupBehavior.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube.Behaviors;
+
+internal sealed class ShortsWarmupBehavior : IYouTubeWarmupBehavior
+{
+    private readonly ILogger<ShortsWarmupBehavior>? _logger;
+
+    public ShortsWarmupBehavior(ILogger<ShortsWarmupBehavior>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public string Name => "Shorts";
+
+    public YouTubeWarmupBehaviorKind Kind => YouTubeWarmupBehaviorKind.Shorts;
+
+    public IEnumerable<string> Aliases { get; } = new[] { "short", "shorts" };
+
+    public bool Matches(string identifier)
+        => Aliases.Any(alias => alias.Equals(identifier, StringComparison.OrdinalIgnoreCase));
+
+    public async Task<bool> ExecuteAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        if (page == null || mouse == null)
+        {
+            return false;
+        }
+
+        bool navigated = await TryOpenShortsFeedAsync(context, config, token);
+        if (!navigated)
+        {
+            return false;
+        }
+
+        int sequenceLength = context.Random.Next(
+            Math.Max(1, config.MinShortSequenceLength),
+            Math.Max(Math.Max(1, config.MinShortSequenceLength), config.MaxShortSequenceLength) + 1);
+
+        for (int i = 0; i < sequenceLength; i++)
+        {
+            int watchMs = context.Random.Next(
+                Math.Max(1000, config.MinShortWatchMilliseconds),
+                Math.Max(Math.Max(1000, config.MinShortWatchMilliseconds), config.MaxShortWatchMilliseconds) + 1);
+
+            await context.WatchVideoAsync(config, token, TimeSpan.FromMilliseconds(watchMs), isShort: true);
+
+            if (i < sequenceLength - 1)
+            {
+                string key = context.Random.NextDouble() < 0.65 ? "ArrowDown" : "PageDown";
+                await page.Keyboard.PressAsync(key);
+                await Task.Delay(context.Random.Next(800, 1600), token);
+            }
+        }
+
+        context.IncrementShortsInteractions();
+        return true;
+    }
+
+    private async Task<bool> TryOpenShortsFeedAsync(WarmupContext context, YouTubeWarmupSettings config, CancellationToken token)
+    {
+        var page = context.Page;
+        var mouse = context.Mouse;
+        if (page == null || mouse == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var menuItems = page.Locator("#items ytd-mini-guide-entry-renderer");
+            int count = await menuItems.CountAsync();
+            for (int i = 0; i < Math.Min(count, 8); i++)
+            {
+                var entry = menuItems.Nth(i);
+                string label = (await entry.InnerTextAsync(new() { Timeout = 1000 }))?.Trim() ?? string.Empty;
+                if (label.IndexOf("shorts", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    await mouse.MoveAndClickAsync(entry);
+                    await context.WaitForNavigationAsync(token);
+                    return true;
+                }
+            }
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Mini guide navigation to Shorts failed; falling back to direct navigation.");
+        }
+
+        string fallback = config.Domains?.FirstOrDefault(d => d.Contains("/shorts", StringComparison.OrdinalIgnoreCase))
+            ?? "https://www.youtube.com/shorts";
+
+        try
+        {
+            await page.GotoAsync(fallback, new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60000 });
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 20000 });
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogWarning(ex, "Failed to open Shorts experience at {Url}.", fallback);
+            return false;
+        }
+    }
+}

--- a/Services/YouTube/PlayerControlHelper.cs
+++ b/Services/YouTube/PlayerControlHelper.cs
@@ -87,6 +87,64 @@ internal class PlayerControlHelper
         }
     }
 
+    public async Task<VideoPlaybackMetadata?> TryGetPlaybackMetadataAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            var result = await _page.EvaluateAsync<VideoMetadataResult?>(
+                @"() => {
+                    const video = document.querySelector('video.html5-main-video')
+                        || document.querySelector('#shorts-player video')
+                        || document.querySelector('#reel-video-renderer video');
+                    if (!video) {
+                        return null;
+                    }
+
+                    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null;
+                    const current = Number.isFinite(video.currentTime) && video.currentTime >= 0 ? video.currentTime : null;
+                    const isShort = Boolean(document.location?.pathname?.startsWith('/shorts'))
+                        || Boolean(document.querySelector('#shorts-player, #reel-video-renderer'));
+
+                    return {
+                        DurationSeconds: duration,
+                        CurrentSeconds: current,
+                        IsShort: isShort
+                    };
+                }");
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            TimeSpan? duration = result.DurationSeconds is double durationSeconds
+                ? TimeSpan.FromSeconds(Math.Max(0, durationSeconds))
+                : null;
+            TimeSpan? position = result.CurrentSeconds is double currentSeconds
+                ? TimeSpan.FromSeconds(Math.Max(0, currentSeconds))
+                : null;
+
+            if (duration is TimeSpan total && double.IsInfinity(total.TotalSeconds))
+            {
+                duration = null;
+            }
+
+            return new VideoPlaybackMetadata
+            {
+                Duration = duration,
+                Position = position,
+                IsShort = result.IsShort
+            };
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogTrace(ex, "Unable to query YouTube playback metadata.");
+            return null;
+        }
+    }
+
     public async Task<bool> WaitForPlayerReadyAsync(CancellationToken cancellationToken, int timeoutMilliseconds = 15000)
     {
         DateTime deadline = DateTime.UtcNow.AddMilliseconds(Math.Max(1000, timeoutMilliseconds));
@@ -430,5 +488,38 @@ internal class PlayerControlHelper
             default:
                 return false;
         }
+    }
+
+    internal sealed class VideoPlaybackMetadata
+    {
+        public TimeSpan? Duration { get; init; }
+
+        public TimeSpan? Position { get; init; }
+
+        public bool IsShort { get; init; }
+
+        public TimeSpan? Remaining
+        {
+            get
+            {
+                if (Duration is not TimeSpan total)
+                {
+                    return null;
+                }
+
+                double currentSeconds = Math.Max(0, Position?.TotalSeconds ?? 0);
+                double remainingSeconds = Math.Max(0, total.TotalSeconds - currentSeconds);
+                return TimeSpan.FromSeconds(remainingSeconds);
+            }
+        }
+    }
+
+    private sealed class VideoMetadataResult
+    {
+        public double? DurationSeconds { get; set; }
+
+        public double? CurrentSeconds { get; set; }
+
+        public bool IsShort { get; set; }
     }
 }

--- a/Services/YouTube/PlayerControlHelper.cs
+++ b/Services/YouTube/PlayerControlHelper.cs
@@ -14,13 +14,39 @@ namespace GPM_driver.Services.YouTube;
 /// </summary>
 internal class PlayerControlHelper
 {
+    internal enum PlayerControlAction
+    {
+        TogglePlayPause,
+        ToggleMute,
+        AdjustVolumeSlider,
+        AdjustVolumeKeys,
+        SeekRelative,
+        ToggleFullScreen,
+        ToggleTheaterMode,
+        ChangePlaybackSpeed
+    }
+
     private static readonly string[] SkipButtonSelectors =
     {
         "button.ytp-ad-skip-button-modern",
         ".ytp-ad-skip-button",
         ".ytp-ad-skip-button-container button",
-        "button.ytp-skip-ad-button"
+        "button.ytp-skip-ad-button",
+        ".ytp-skip-ad-button"
     };
+
+    private static readonly IReadOnlyDictionary<PlayerControlAction, double> DefaultWeights =
+        new Dictionary<PlayerControlAction, double>
+        {
+            [PlayerControlAction.TogglePlayPause] = 1.0,
+            [PlayerControlAction.SeekRelative] = 0.85,
+            [PlayerControlAction.ToggleMute] = 0.65,
+            [PlayerControlAction.AdjustVolumeKeys] = 0.55,
+            [PlayerControlAction.ChangePlaybackSpeed] = 0.45,
+            [PlayerControlAction.ToggleTheaterMode] = 0.35,
+            [PlayerControlAction.AdjustVolumeSlider] = 0.30,
+            [PlayerControlAction.ToggleFullScreen] = 0.25
+        };
 
     private readonly IPage _page;
     private readonly MouseHelper _mouseHelper;
@@ -33,6 +59,8 @@ internal class PlayerControlHelper
         _mouseHelper = mouseHelper ?? new MouseHelper(page);
         _logger = logger;
     }
+
+    public static IReadOnlyDictionary<PlayerControlAction, double> DefaultActionWeights => DefaultWeights;
 
     public async Task<bool> EnsurePlayerVisibleAsync()
     {
@@ -112,7 +140,12 @@ internal class PlayerControlHelper
 
     public async Task<bool> HandleAdsAsync(CancellationToken cancellationToken)
     {
-        if (!await IsAdShowingAsync(cancellationToken))
+        if (await TrySkipAdAsync(cancellationToken))
+        {
+            return true;
+        }
+
+        if (!await IsAdShowingAsync(cancellationToken) && !await IsAdOverlayBlockingControlsAsync(cancellationToken))
         {
             return false;
         }
@@ -123,7 +156,7 @@ internal class PlayerControlHelper
         }
 
         _logger?.LogDebug("Ad playing without skip option; waiting briefly.");
-        await DelayAsync(_random.Next(1200, 2200), cancellationToken);
+        await WaitForAdToFinishAsync(cancellationToken);
         return true;
     }
 
@@ -132,7 +165,7 @@ internal class PlayerControlHelper
         foreach (string selector in SkipButtonSelectors)
         {
             var locator = _page.Locator(selector);
-            if (!await locator.IsVisibleAsync(new() { Timeout = 100 }))
+            if (!await locator.IsVisibleAsync(new() { Timeout = 200 }))
             {
                 continue;
             }
@@ -174,20 +207,36 @@ internal class PlayerControlHelper
         }
     }
 
+    public async Task<bool> IsAdOverlayBlockingControlsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var overlay = _page.Locator("div.video-ads.ytp-ad-module");
+            return await overlay.IsVisibleAsync(new() { Timeout = 100 });
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
+    }
+
     public async Task WaitForAdToFinishAsync(CancellationToken cancellationToken)
     {
         var start = DateTime.UtcNow;
-        while (DateTime.UtcNow - start < TimeSpan.FromSeconds(20))
+        while (DateTime.UtcNow - start < TimeSpan.FromSeconds(45))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!await IsAdShowingAsync(cancellationToken))
+            bool adShowing = await IsAdShowingAsync(cancellationToken);
+            bool overlayBlocking = await IsAdOverlayBlockingControlsAsync(cancellationToken);
+
+            if (!adShowing && !overlayBlocking)
             {
                 await DelayAsync(_random.Next(300, 700), cancellationToken);
                 return;
             }
 
-            await DelayAsync(_random.Next(500, 900), cancellationToken);
+            await DelayAsync(_random.Next(600, 900), cancellationToken);
         }
     }
 
@@ -221,6 +270,7 @@ internal class PlayerControlHelper
 
         try
         {
+            await _mouseHelper.MoveToAsync(slider);
             await slider.ClickAsync(new() { Position = new() { X = offsetX, Y = offsetY } });
             _logger?.LogTrace("Adjusted volume slider to {Ratio:P0}.", ratio);
             return true;
@@ -287,6 +337,38 @@ internal class PlayerControlHelper
         }
     }
 
+    public async Task<bool> IsFullScreenActiveAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _page.EvaluateAsync<bool>(
+                "() => {\n                    const player = document.querySelector('#movie_player, .html5-video-player, ytd-player');\n                    if (document.fullscreenElement) {\n                        return true;\n                    }\n                    return Boolean(player?.classList?.contains('ytp-fullscreen'));\n                }");
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
+    }
+
+    public async Task ExitFullScreenAsync(CancellationToken cancellationToken)
+    {
+        if (!await IsFullScreenActiveAsync(cancellationToken))
+        {
+            return;
+        }
+
+        bool toggled = await NavigationPattern.TryPressAsync(_page, "f", logger: _logger, cancellationToken: cancellationToken);
+        await DelayAsync(_random.Next(200, 400), cancellationToken);
+
+        if (!toggled || await IsFullScreenActiveAsync(cancellationToken))
+        {
+            await NavigationPattern.TryPressAsync(_page, "Escape", logger: _logger, cancellationToken: cancellationToken);
+            await DelayAsync(_random.Next(200, 400), cancellationToken);
+        }
+    }
+
     public async Task DelayAsync(int milliseconds, CancellationToken cancellationToken)
     {
         if (milliseconds <= 0)
@@ -319,32 +401,34 @@ internal class PlayerControlHelper
         }
     }
 
-    public async Task PerformRandomControlActionAsync(CancellationToken cancellationToken)
+    public async Task<bool> TryPerformActionAsync(PlayerControlAction action, CancellationToken cancellationToken)
     {
-        var actions = new List<Func<CancellationToken, Task<bool>>>
+        if (await IsAdOverlayBlockingControlsAsync(cancellationToken))
         {
-            TogglePlayPauseAsync,
-            ToggleMuteAsync,
-            AdjustVolumeViaSliderAsync,
-            AdjustVolumeViaKeysAsync,
-            async token => await SeekRelativeAsync(_random.NextDouble() * 0.3 - 0.15, token),
-            ToggleFullScreenAsync,
-            ToggleTheaterModeAsync,
-            ChangePlaybackSpeedAsync
-        };
+            return false;
+        }
 
-        int attempts = 0;
-        while (attempts < actions.Count)
+        switch (action)
         {
-            int index = _random.Next(actions.Count);
-            var action = actions[index];
-            bool success = await action(cancellationToken);
-            if (success)
-            {
-                return;
-            }
-
-            attempts++;
+            case PlayerControlAction.TogglePlayPause:
+                return await TogglePlayPauseAsync(cancellationToken);
+            case PlayerControlAction.ToggleMute:
+                return await ToggleMuteAsync(cancellationToken);
+            case PlayerControlAction.AdjustVolumeSlider:
+                return await AdjustVolumeViaSliderAsync(cancellationToken);
+            case PlayerControlAction.AdjustVolumeKeys:
+                return await AdjustVolumeViaKeysAsync(cancellationToken);
+            case PlayerControlAction.SeekRelative:
+                double delta = _random.NextDouble() * 0.25 - 0.125;
+                return await SeekRelativeAsync(delta, cancellationToken);
+            case PlayerControlAction.ToggleFullScreen:
+                return await ToggleFullScreenAsync(cancellationToken);
+            case PlayerControlAction.ToggleTheaterMode:
+                return await ToggleTheaterModeAsync(cancellationToken);
+            case PlayerControlAction.ChangePlaybackSpeed:
+                return await ChangePlaybackSpeedAsync(cancellationToken);
+            default:
+                return false;
         }
     }
 }

--- a/Services/YouTube/PlayerControlHelper.cs
+++ b/Services/YouTube/PlayerControlHelper.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+/// <summary>
+/// Consolidates common control interactions with the YouTube HTML5 player. Activities can rely on
+/// this helper instead of re-implementing selectors, key presses or guard logic for ads.
+/// </summary>
+internal class PlayerControlHelper
+{
+    private static readonly string[] SkipButtonSelectors =
+    {
+        "button.ytp-ad-skip-button-modern",
+        ".ytp-ad-skip-button",
+        ".ytp-ad-skip-button-container button",
+        "button.ytp-skip-ad-button"
+    };
+
+    private readonly IPage _page;
+    private readonly MouseHelper _mouseHelper;
+    private readonly ILogger? _logger;
+    private readonly Random _random = RandomProvider.Shared;
+
+    public PlayerControlHelper(IPage page, MouseHelper? mouseHelper = null, ILogger? logger = null)
+    {
+        _page = page ?? throw new ArgumentNullException(nameof(page));
+        _mouseHelper = mouseHelper ?? new MouseHelper(page);
+        _logger = logger;
+    }
+
+    public async Task<bool> EnsurePlayerVisibleAsync()
+    {
+        var video = _page.Locator("video.html5-main-video");
+        try
+        {
+            return await video.IsVisibleAsync(new() { Timeout = 5000 });
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> HandleAdsAsync(CancellationToken cancellationToken)
+    {
+        if (!await IsAdShowingAsync(cancellationToken))
+        {
+            return false;
+        }
+
+        if (await TrySkipAdAsync(cancellationToken))
+        {
+            return true;
+        }
+
+        _logger?.LogDebug("Ad playing without skip option; waiting briefly.");
+        await DelayAsync(_random.Next(1200, 2200), cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> TrySkipAdAsync(CancellationToken cancellationToken)
+    {
+        foreach (string selector in SkipButtonSelectors)
+        {
+            var locator = _page.Locator(selector);
+            if (!await locator.IsVisibleAsync(new() { Timeout = 100 }))
+            {
+                continue;
+            }
+
+            try
+            {
+                _logger?.LogInformation("Clicking YouTube skip button '{Selector}'.", selector);
+                await _mouseHelper.MoveAndClickAsync(locator);
+                await WaitForAdToFinishAsync(cancellationToken);
+                return true;
+            }
+            catch (PlaywrightException ex)
+            {
+                _logger?.LogDebug(ex, "Failed skipping ad with selector {Selector}.", selector);
+            }
+        }
+
+        return false;
+    }
+
+    public async Task<bool> IsAdShowingAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var player = _page.Locator("#movie_player, .html5-video-player, ytd-player");
+            if (await player.CountAsync() == 0)
+            {
+                return false;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await player.EvaluateAsync<bool>(
+                "player => Boolean(player?.classList?.contains('ad-showing') || player?.classList?.contains('ad-interrupting'))");
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
+    }
+
+    public async Task WaitForAdToFinishAsync(CancellationToken cancellationToken)
+    {
+        var start = DateTime.UtcNow;
+        while (DateTime.UtcNow - start < TimeSpan.FromSeconds(20))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!await IsAdShowingAsync(cancellationToken))
+            {
+                await DelayAsync(_random.Next(300, 700), cancellationToken);
+                return;
+            }
+
+            await DelayAsync(_random.Next(500, 900), cancellationToken);
+        }
+    }
+
+    public async Task<bool> TogglePlayPauseAsync(CancellationToken cancellationToken)
+    {
+        return await NavigationPattern.TryPressAsync(_page, "k", logger: _logger, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> ToggleMuteAsync(CancellationToken cancellationToken)
+    {
+        return await NavigationPattern.TryPressAsync(_page, "m", probability: 1.0, logger: _logger, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> AdjustVolumeViaSliderAsync(CancellationToken cancellationToken)
+    {
+        var slider = _page.Locator(".ytp-volume-slider");
+        if (!await slider.IsVisibleAsync(new() { Timeout = 500 }))
+        {
+            return false;
+        }
+
+        var box = await slider.BoundingBoxAsync();
+        if (box == null)
+        {
+            return false;
+        }
+
+        double ratio = _random.NextDouble();
+        float offsetX = (float)(box.Width * ratio);
+        float offsetY = (float)(box.Height / 2);
+
+        try
+        {
+            await slider.ClickAsync(new() { Position = new() { X = offsetX, Y = offsetY } });
+            _logger?.LogTrace("Adjusted volume slider to {Ratio:P0}.", ratio);
+            return true;
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed adjusting YouTube volume slider.");
+            return false;
+        }
+    }
+
+    public async Task<bool> AdjustVolumeViaKeysAsync(CancellationToken cancellationToken)
+    {
+        string key = _random.NextDouble() < 0.5 ? "ArrowUp" : "ArrowDown";
+        return await NavigationPattern.TryPressAsync(_page, key, logger: _logger, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> SeekRelativeAsync(double percentageDelta, CancellationToken cancellationToken)
+    {
+        percentageDelta = Math.Clamp(percentageDelta, -0.9, 0.9);
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _page.EvaluateAsync<bool>(
+                "delta => {\n                    const video = document.querySelector('video.html5-main-video');\n                    if (!video || !isFinite(video.duration) || video.duration <= 0) {\n                        return false;\n                    }\n                    const normalized = Math.min(0.995, Math.max(0.005, (video.currentTime / video.duration) + delta));\n                    const newTime = video.duration * normalized;\n                    if (Math.abs(newTime - video.currentTime) < 0.25) {\n                        return false;\n                    }\n                    video.currentTime = newTime;\n                    return true;\n                }",
+                percentageDelta);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed seeking video by delta {Delta}.", percentageDelta);
+            return false;
+        }
+    }
+
+    public async Task<bool> ToggleFullScreenAsync(CancellationToken cancellationToken)
+    {
+        return await NavigationPattern.TryPressAsync(_page, "f", logger: _logger, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> ToggleTheaterModeAsync(CancellationToken cancellationToken)
+    {
+        return await NavigationPattern.TryPressAsync(_page, "t", logger: _logger, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> ChangePlaybackSpeedAsync(CancellationToken cancellationToken)
+    {
+        double[] speeds = { 0.75, 1.0, 1.25, 1.5, 1.75, 2.0 };
+        double target = speeds[_random.Next(speeds.Length)];
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _page.EvaluateAsync<bool>(
+                "speed => {\n                    const video = document.querySelector('video.html5-main-video');\n                    if (!video) {\n                        return false;\n                    }\n                    if (Math.abs(video.playbackRate - speed) < 0.01) {\n                        const alternatives = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];\n                        const different = alternatives.find(s => Math.abs(s - video.playbackRate) > 0.01);\n                        if (different) {\n                            video.playbackRate = different;\n                            return true;\n                        }\n                        return false;\n                    }\n                    video.playbackRate = speed;\n                    return true;\n                }",
+                target);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Failed setting playback speed to {Speed}.", target);
+            return false;
+        }
+    }
+
+    public async Task DelayAsync(int milliseconds, CancellationToken cancellationToken)
+    {
+        if (milliseconds <= 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(milliseconds, cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            // Activity handles cancellation.
+        }
+    }
+
+    public async Task<bool> EnsureVideoPlayingAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _page.EvaluateAsync<bool>(
+                "() => {\n                    const video = document.querySelector('video.html5-main-video');\n                    if (!video) return false;\n                    if (video.paused) {\n                        video.play();\n                        return false;\n                    }\n                    return true;\n                }");
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
+    }
+
+    public async Task PerformRandomControlActionAsync(CancellationToken cancellationToken)
+    {
+        var actions = new List<Func<CancellationToken, Task<bool>>>
+        {
+            TogglePlayPauseAsync,
+            ToggleMuteAsync,
+            AdjustVolumeViaSliderAsync,
+            AdjustVolumeViaKeysAsync,
+            async token => await SeekRelativeAsync(_random.NextDouble() * 0.3 - 0.15, token),
+            ToggleFullScreenAsync,
+            ToggleTheaterModeAsync,
+            ChangePlaybackSpeedAsync
+        };
+
+        int attempts = 0;
+        while (attempts < actions.Count)
+        {
+            int index = _random.Next(actions.Count);
+            var action = actions[index];
+            bool success = await action(cancellationToken);
+            if (success)
+            {
+                return;
+            }
+
+            attempts++;
+        }
+    }
+}

--- a/Services/YouTube/PlayerControlHelper.cs
+++ b/Services/YouTube/PlayerControlHelper.cs
@@ -36,10 +36,22 @@ internal class PlayerControlHelper
 
     public async Task<bool> EnsurePlayerVisibleAsync()
     {
-        var video = _page.Locator("video.html5-main-video");
         try
         {
-            return await video.IsVisibleAsync(new() { Timeout = 5000 });
+            var standardPlayer = _page.Locator("#movie_player");
+            if (await standardPlayer.IsVisibleAsync(new() { Timeout = 5000 }))
+            {
+                return true;
+            }
+
+            var shortsPlayer = _page.Locator("#reel-video-renderer");
+            if (await shortsPlayer.IsVisibleAsync(new() { Timeout = 2000 }))
+            {
+                return true;
+            }
+
+            var video = _page.Locator("video.html5-main-video");
+            return await video.IsVisibleAsync(new() { Timeout = 2000 });
         }
         catch
         {

--- a/Services/YouTube/PlayerControlHelper.cs
+++ b/Services/YouTube/PlayerControlHelper.cs
@@ -59,6 +59,57 @@ internal class PlayerControlHelper
         }
     }
 
+    public async Task<bool> WaitForPlayerReadyAsync(CancellationToken cancellationToken, int timeoutMilliseconds = 15000)
+    {
+        DateTime deadline = DateTime.UtcNow.AddMilliseconds(Math.Max(1000, timeoutMilliseconds));
+
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await EnsurePlayerVisibleAsync())
+            {
+                try
+                {
+                    bool ready = await _page.EvaluateAsync<bool>(
+                        @"() => {
+                            const player = document.querySelector('#movie_player, .html5-video-player, ytd-player');
+                            const video = document.querySelector('video.html5-main-video')
+                                || document.querySelector('#shorts-player video')
+                                || document.querySelector('#reel-video-renderer video');
+                            if (!player || !video) {
+                                return false;
+                            }
+                            if (player.classList?.contains('ad-showing') || player.classList?.contains('ad-interrupting')) {
+                                return false;
+                            }
+                            if (video.readyState >= 2 && !video.paused) {
+                                return true;
+                            }
+                            if (video.readyState >= 2) {
+                                try { video.play?.(); } catch (e) { }
+                            }
+                            return false;
+                        }");
+
+                    if (ready)
+                    {
+                        return true;
+                    }
+                }
+                catch (PlaywrightException ex)
+                {
+                    _logger?.LogTrace(ex, "Player readiness check failed.");
+                }
+            }
+
+            await DelayAsync(_random.Next(250, 450), cancellationToken);
+        }
+
+        _logger?.LogDebug("Timed out waiting for YouTube player to become ready.");
+        return false;
+    }
+
     public async Task<bool> HandleAdsAsync(CancellationToken cancellationToken)
     {
         if (!await IsAdShowingAsync(cancellationToken))

--- a/Services/YouTube/WarmupContext.cs
+++ b/Services/YouTube/WarmupContext.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GPM_driver.Helpers;
+using GPM_driver.Models;
+using GPM_driver.Services.YouTube;
+using GPM_driver.Services.YouTube.Activities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace GPM_driver.Services.YouTube;
+
+internal sealed class WarmupContext
+{
+    private readonly ILogger<WarmupContext>? _logger;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    private PlayerControlHelper? _playerControls;
+    private VideoPlayerActivity? _videoActivity;
+
+    private int _searchInteractions;
+    private int _homeInteractions;
+    private int _shortsInteractions;
+    private int _recommendationInteractions;
+
+    public WarmupContext(
+        IBrowserContext browserContext,
+        ILogger<WarmupContext>? logger = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        BrowserContext = browserContext ?? throw new ArgumentNullException(nameof(browserContext));
+        _logger = logger;
+        _loggerFactory = loggerFactory;
+        Random = RandomProvider.Shared;
+    }
+
+    public IBrowserContext BrowserContext { get; }
+
+    public Random Random { get; }
+
+    public string? KeywordDirectory { get; set; }
+
+    public IPage? Page { get; private set; }
+
+    public MouseHelper? Mouse { get; private set; }
+
+    public KeyboardHelper? Keyboard { get; private set; }
+
+    public HashSet<string> VisitedVideoIds { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public PlayerControlHelper PlayerControls
+    {
+        get
+        {
+            if (_playerControls == null && Page != null)
+            {
+                _playerControls = new PlayerControlHelper(
+                    Page,
+                    Mouse,
+                    _loggerFactory?.CreateLogger<PlayerControlHelper>());
+            }
+
+            return _playerControls ?? throw new InvalidOperationException("Warmup context is not initialised.");
+        }
+    }
+
+    public VideoPlayerActivity VideoActivity
+    {
+        get
+        {
+            if (_videoActivity == null && Page != null)
+            {
+                _videoActivity = new VideoPlayerActivity(
+                    Page,
+                    _loggerFactory?.CreateLogger<VideoPlayerActivity>(),
+                    PlayerControls);
+            }
+
+            return _videoActivity ?? throw new InvalidOperationException("Warmup context is not initialised.");
+        }
+    }
+
+    public int SearchInteractions => _searchInteractions;
+
+    public int HomeInteractions => _homeInteractions;
+
+    public int ShortsInteractions => _shortsInteractions;
+
+    public int RecommendationInteractions => _recommendationInteractions;
+
+    public async Task<IPage> EnsurePageAsync(CancellationToken token)
+    {
+        if (Page != null && !Page.IsClosed)
+        {
+            return Page;
+        }
+
+        var existing = BrowserContext.Pages.FirstOrDefault(static p => !p.IsClosed);
+        if (existing != null)
+        {
+            Page = existing;
+        }
+        else
+        {
+            _logger?.LogDebug("Opening new page for YouTube warmup context.");
+            Page = await BrowserContext.NewPageAsync();
+        }
+
+        Mouse = new MouseHelper(Page);
+        Keyboard = new KeyboardHelper(Page);
+        _playerControls = null;
+        _videoActivity = null;
+
+        return Page;
+    }
+
+    public async Task EnsureLandingDomainAsync(YouTubeWarmupSettings config, CancellationToken token)
+    {
+        if (Page == null)
+        {
+            return;
+        }
+
+        string[] domains = config.Domains?.Length > 0
+            ? config.Domains
+            : new[] { "https://www.youtube.com" };
+
+        if (domains.Any(domain => Page.Url.StartsWith(domain, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        string target = domains[Random.Next(domains.Length)];
+        _logger?.LogInformation("Navigating to YouTube domain {Domain} to begin warmup.", target);
+        await Page.GotoAsync(target, new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60000 });
+        await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 30000 });
+    }
+
+    public async Task<bool> IsFreshLandingExperienceAsync(CancellationToken token)
+    {
+        if (Page == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var contentWrapper = Page.Locator("#content-wrapper");
+            if (!await contentWrapper.IsVisibleAsync(new() { Timeout = 1500 }))
+            {
+                return false;
+            }
+
+            string text = (await contentWrapper.InnerTextAsync(new() { Timeout = 1500 })) ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            string[] markers =
+            {
+                "thử tìm kiếm để bắt đầu",
+                "try searching to get started"
+            };
+
+            return markers.Any(marker =>
+                text.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
+    }
+
+    public async Task NavigateToHomeAsync(YouTubeWarmupSettings config, CancellationToken token)
+    {
+        if (Page == null)
+        {
+            return;
+        }
+
+        if (Page.Url.StartsWith("https://www.youtube.com/", StringComparison.OrdinalIgnoreCase) &&
+            !Page.Url.Contains("watch", StringComparison.OrdinalIgnoreCase) &&
+            !Page.Url.Contains("results", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string home = config.Domains?.FirstOrDefault(d =>
+            d.Contains("youtube.com", StringComparison.OrdinalIgnoreCase) &&
+            !d.Contains("/shorts", StringComparison.OrdinalIgnoreCase))
+            ?? "https://www.youtube.com";
+
+        await Page.GotoAsync(home, new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60000 });
+        await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 20000 });
+    }
+
+    public async Task WaitForNavigationAsync(CancellationToken token)
+    {
+        if (Page == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 30000 });
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = 30000 });
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Wait for navigation timed out but continuing warmup.");
+        }
+    }
+
+    public async Task WatchVideoAsync(
+        YouTubeWarmupSettings config,
+        CancellationToken token,
+        TimeSpan? explicitDuration = null,
+        bool isShort = false)
+    {
+        if (Page == null)
+        {
+            return;
+        }
+
+        int min = isShort ? config.MinShortWatchMilliseconds : config.MinWatchMilliseconds;
+        int max = isShort ? config.MaxShortWatchMilliseconds : config.MaxWatchMilliseconds;
+
+        if (max < min)
+        {
+            max = min;
+        }
+
+        TimeSpan duration = explicitDuration ?? TimeSpan.FromMilliseconds(
+            Random.Next(Math.Max(1000, min), Math.Max(1000, max) + 1));
+
+        var activity = VideoActivity;
+        activity.MinDelayBetweenActionsMs = Math.Max(1200, config.MinDelayBetweenActionsMs);
+        activity.MaxDelayBetweenActionsMs = Math.Max(activity.MinDelayBetweenActionsMs + 1000, config.MaxDelayBetweenActionsMs);
+
+        try
+        {
+            await activity.WatchCurrentVideoAsync(duration, token);
+        }
+        catch (PlaywrightException ex)
+        {
+            _logger?.LogDebug(ex, "Watch routine encountered an issue.");
+        }
+
+        TrackVisitedVideo(Page.Url);
+    }
+
+    public async Task DelayBetweenActionsAsync(YouTubeWarmupSettings config, CancellationToken token)
+    {
+        int minDelay = Math.Max(0, config.MinDelayBetweenActionsMs);
+        int maxDelay = Math.Max(minDelay, config.MaxDelayBetweenActionsMs);
+        int delay = Random.Next(minDelay, maxDelay + 1);
+        await Task.Delay(delay, token);
+    }
+
+    public void IncrementSearchInteractions() => _searchInteractions++;
+
+    public void IncrementHomeInteractions() => _homeInteractions++;
+
+    public void IncrementShortsInteractions() => _shortsInteractions++;
+
+    public void IncrementRecommendationInteractions() => _recommendationInteractions++;
+
+    public async Task PersistSessionStateAsync(YouTubeWarmupSettings config, string? profileId, CancellationToken token)
+    {
+        if (string.IsNullOrWhiteSpace(config.IdentityCacheDirectory))
+        {
+            return;
+        }
+
+        try
+        {
+            string directory = config.IdentityCacheDirectory;
+            if (!Path.IsPathRooted(directory))
+            {
+                directory = Path.Combine(AppContext.BaseDirectory, directory);
+            }
+
+            Directory.CreateDirectory(directory);
+
+            string fileName = string.IsNullOrWhiteSpace(profileId)
+                ? "youtube-warmup-session.json"
+                : $"youtube-warmup-session-{SanitizeFileName(profileId)}.json";
+
+            var payload = new
+            {
+                ProfileId = profileId,
+                TimestampUtc = DateTime.UtcNow,
+                SearchInteractions = _searchInteractions,
+                HomeInteractions = _homeInteractions,
+                ShortsInteractions = _shortsInteractions,
+                RecommendationInteractions = _recommendationInteractions,
+                VisitedVideoIds = VisitedVideoIds.ToArray()
+            };
+
+            string json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            string path = Path.Combine(directory, fileName);
+            await File.WriteAllTextAsync(path, json, token);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogDebug(ex, "Unable to persist YouTube warmup identity cache.");
+        }
+    }
+
+    public string ExtractVideoId(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return string.Empty;
+        }
+
+        if (uri.AbsolutePath.Contains("/shorts", StringComparison.OrdinalIgnoreCase))
+        {
+            string segment = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? string.Empty;
+            return segment;
+        }
+
+        if (string.IsNullOrEmpty(uri.Query))
+        {
+            return string.Empty;
+        }
+
+        foreach (var part in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var kv = part.Split('=', 2, StringSplitOptions.RemoveEmptyEntries);
+            if (kv.Length == 0)
+            {
+                continue;
+            }
+
+            if (kv[0].Equals("v", StringComparison.OrdinalIgnoreCase))
+            {
+                return kv.Length == 2 ? kv[1] : string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private void TrackVisitedVideo(string? url)
+    {
+        string id = ExtractVideoId(url);
+        if (!string.IsNullOrEmpty(id))
+        {
+            VisitedVideoIds.Add(id);
+        }
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        foreach (char invalid in Path.GetInvalidFileNameChars())
+        {
+            value = value.Replace(invalid, '_');
+        }
+
+        return value;
+    }
+}

--- a/Services/YouTube/WarmupContext.cs
+++ b/Services/YouTube/WarmupContext.cs
@@ -245,7 +245,7 @@ internal sealed class WarmupContext
 
         try
         {
-            await activity.WatchCurrentVideoAsync(duration, token);
+            await activity.WatchCurrentVideoAsync(duration, token, isShort ? true : null);
         }
         catch (PlaywrightException ex)
         {

--- a/Services/YouTubeWarmupService.cs
+++ b/Services/YouTubeWarmupService.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
-using GPM_driver.Helpers;
 using GPM_driver.Models;
 using GPM_driver.Services.YouTube;
+using GPM_driver.Services.YouTube.Behaviors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 
@@ -15,17 +14,109 @@ namespace GPM_driver.Services;
 internal class YouTubeWarmupService
 {
     private readonly IBrowserContext _context;
+    private readonly IEnumerable<IYouTubeWarmupBehavior> _behaviors;
+    private readonly BehaviorWeightCalculator _weightCalculator;
     private readonly ILogger<YouTubeWarmupService>? _logger;
-    private readonly Random _random = RandomProvider.Shared;
+    private readonly ILoggerFactory? _loggerFactory;
 
-    private IPage? _page;
-    private MouseHelper? _mouseHelper;
-    private KeyboardHelper? _keyboardHelper;
-
-
-    public YouTubeWarmupService(IBrowserContext context, ILogger<YouTubeWarmupService>? logger = null)
+    public YouTubeWarmupService(
+        IBrowserContext context,
+        IEnumerable<IYouTubeWarmupBehavior> behaviors,
+        BehaviorWeightCalculator weightCalculator,
+        ILogger<YouTubeWarmupService>? logger = null,
+        ILoggerFactory? loggerFactory = null)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        _behaviors = behaviors ?? throw new ArgumentNullException(nameof(behaviors));
+        _weightCalculator = weightCalculator ?? throw new ArgumentNullException(nameof(weightCalculator));
         _logger = logger;
+        _loggerFactory = loggerFactory;
+    }
+
+    public async Task RunWarmupAsync(
+        string? keywordDirectory,
+        YouTubeWarmupSettings warmupConfig,
+        string? profileId,
+        CancellationToken token = default)
+    {
+        if (warmupConfig == null)
+        {
+            throw new ArgumentNullException(nameof(warmupConfig));
+        }
+
+        var warmupContext = new WarmupContext(
+            _context,
+            _loggerFactory?.CreateLogger<WarmupContext>(),
+            _loggerFactory)
+        {
+            KeywordDirectory = keywordDirectory
+        };
+
+        await warmupContext.EnsurePageAsync(token);
+        await warmupContext.EnsureLandingDomainAsync(warmupConfig, token);
+
+        bool freshLanding = await warmupContext.IsFreshLandingExperienceAsync(token);
+        _logger?.LogInformation(
+            freshLanding
+                ? "Detected fresh YouTube landing experience. Prioritising search and Shorts warmup."
+                : "YouTube landing shows personalised feed. Running full warmup mix.");
+
+        var weightedBehaviors = _weightCalculator.Calculate(_behaviors, warmupConfig, freshLanding);
+        if (weightedBehaviors.Count == 0)
+        {
+            _logger?.LogWarning("No warmup behaviours available; skipping YouTube warmup.");
+            return;
+        }
+
+        int interactions = warmupContext.Random.Next(
+            Math.Max(1, warmupConfig.MinInteractions),
+            Math.Max(Math.Max(1, warmupConfig.MinInteractions), warmupConfig.MaxInteractions) + 1);
+
+        for (int i = 0; i < interactions && !token.IsCancellationRequested; i++)
+        {
+            var behavior = _weightCalculator.PickBehavior(weightedBehaviors, warmupContext.Random);
+            if (behavior == null)
+            {
+                break;
+            }
+
+            _logger?.LogDebug(
+                "Executing YouTube warmup behaviour {Behaviour} ({Index}/{Total}).",
+                behavior.Name,
+                i + 1,
+                interactions);
+
+            bool success = false;
+            try
+            {
+                success = await behavior.ExecuteAsync(warmupContext, warmupConfig, token);
+            }
+            catch (PlaywrightException ex)
+            {
+                _logger?.LogDebug(ex, "Behaviour {Behaviour} threw a Playwright exception.", behavior.Name);
+            }
+
+            if (!success)
+            {
+                _logger?.LogDebug(
+                    "Behaviour {Behaviour} did not complete successfully; continuing with next action.",
+                    behavior.Name);
+            }
+
+            if (i < interactions - 1)
+            {
+                await warmupContext.DelayBetweenActionsAsync(warmupConfig, token);
+            }
+        }
+
+        await warmupContext.PersistSessionStateAsync(warmupConfig, profileId, token);
+
+        _logger?.LogInformation(
+            "YouTube warmup finished with {Search} searches, {Home} home plays, {Shorts} shorts sequences, {Recommendations} recommendation hops. Visited {Videos} unique videos.",
+            warmupContext.SearchInteractions,
+            warmupContext.HomeInteractions,
+            warmupContext.ShortsInteractions,
+            warmupContext.RecommendationInteractions,
+            warmupContext.VisitedVideoIds.Count);
     }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -43,6 +43,37 @@
       ]
     },
     "YouTubeWarmup": {
+      "Enabled": true,
+      "MinInteractions": 3,
+      "MaxInteractions": 6,
+      "MinWatchMilliseconds": 25000,
+      "MaxWatchMilliseconds": 60000,
+      "MinShortWatchMilliseconds": 9000,
+      "MaxShortWatchMilliseconds": 22000,
+      "SearchWeight": 0.5,
+      "ShortsWeight": 0.25,
+      "HomeWeight": 0.35,
+      "RecommendationsWeight": 0.25,
+      "MinDelayBetweenActionsMs": 2500,
+      "MaxDelayBetweenActionsMs": 5500,
+      "Domains": [
+        "https://www.youtube.com",
+        "https://www.youtube.com/feed/explore",
+        "https://www.youtube.com/shorts"
+      ],
+      "IdentityCacheDirectory": "youtube-identities",
+      "MinRecommendationChainLength": 1,
+      "MaxRecommendationChainLength": 3,
+      "MaxRecommendationDepth": 3,
+      "AutoplayFollowProbability": 0.35,
+      "MinShortSequenceLength": 2,
+      "MaxShortSequenceLength": 5,
+      "Behaviors": [
+        "Search",
+        "Home",
+        "Shorts",
+        "Recommendations"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- extract shared YouTube warmup state into a WarmupContext and update the warmup service to operate on a behavior registry
- implement dedicated search, home, shorts, and recommendation behaviors with centralized weight selection
- add a test project with unit coverage for behavior alias matching and weight calculation

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ef3104988330a372730c43f4bd46